### PR TITLE
fix egs of gsoc:occupiesTimeDirectly & gsoc:occupiesTimeIndirectly

### DIFF
--- a/Loop3D-GSO/Examples/GSO-ExampleIsleOfWightStrat-pm1-v2.ttl
+++ b/Loop3D-GSO/Examples/GSO-ExampleIsleOfWightStrat-pm1-v2.ttl
@@ -100,10 +100,10 @@ bln:BA
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Bartonian"@en ;
-      gsoc:directTemporalOccupies gst:BartonianAge ;
+      gsoc:occupiesTimeDirectly gst:BartonianAge ;
     ] ;
   gsrl:overlies bln:BRB ;
-  gsoq:indirectTemporalOccupies gst:BartonianAge ;
+  gsoc:occupiesTimeIndirectly gst:BartonianAge ;
 .
 bln:BAC
   rdf:type gsgu:Formation ;
@@ -149,10 +149,10 @@ bln:BAC
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Bartonian"@en ;
-      gsoc:directTemporalOccupies gst:BartonianAge ;
+      gsoc:occupiesTimeDirectly gst:BartonianAge ;
     ] ;
   gsrl:overlies bln:SLSY ;
-  gsoq:indirectTemporalOccupies gst:BartonianAge ;
+  gsoc:occupiesTimeIndirectly gst:BartonianAge ;
 .
 bln:BECS
   rdf:type gsgu:Formation ;
@@ -220,10 +220,10 @@ bln:BECS
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Bartonian"@en ;
-      gsoc:directTemporalOccupies gst:BartonianAge ;
+      gsoc:occupiesTimeDirectly gst:BartonianAge ;
     ] ;
   gsrl:overlies bln:CHMS ;
-  gsoq:indirectTemporalOccupies gst:BartonianAge ;
+  gsoc:occupiesTimeIndirectly gst:BartonianAge ;
 .
 bln:BEL
   rdf:type gsgu:Formation ;
@@ -292,10 +292,10 @@ bln:BEL
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:HEHI ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:BMBG
   rdf:type gsgu:Member ;
@@ -363,10 +363,10 @@ bln:BMBG
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:BEL ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:BOUL
   rdf:type gsgu:Formation ;
@@ -423,10 +423,10 @@ bln:BOUL
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Rupelian"@en ;
-      gsoc:directTemporalOccupies gst:RupelianAge ;
+      gsoc:occupiesTimeDirectly gst:RupelianAge ;
     ] ;
   gsrl:overlies bln:BEL ;
-  gsoq:indirectTemporalOccupies gst:RupelianAge ;
+  gsoc:occupiesTimeIndirectly gst:RupelianAge ;
 .
 bln:BRB
   rdf:type gsgu:Group ;
@@ -482,10 +482,10 @@ bln:BRB
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Ypresian"@en ;
-      gsoc:directTemporalOccupies gst:YpresianAge ;
+      gsoc:occupiesTimeDirectly gst:YpresianAge ;
     ] ;
   gsrl:overlies bln:THAM ;
-  gsoq:indirectTemporalOccupies gst:YpresianAge ;
+  gsoc:occupiesTimeIndirectly gst:YpresianAge ;
 .
 bln:CHMS
   rdf:type gsgu:Formation ;
@@ -531,10 +531,10 @@ bln:CHMS
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Bartonian"@en ;
-      gsoc:directTemporalOccupies gst:BartonianAge ;
+      gsoc:occupiesTimeDirectly gst:BartonianAge ;
     ] ;
   gsrl:overlies bln:BAC ;
-  gsoq:indirectTemporalOccupies gst:BartonianAge ;
+  gsoc:occupiesTimeIndirectly gst:BartonianAge ;
 .
 bln:CLEN
   rdf:type gsgu:Member ;
@@ -600,10 +600,10 @@ bln:CLEN
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:CB ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:COLW
   rdf:type gsgu:Member ;
@@ -682,10 +682,10 @@ bln:COLW
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:TOTB ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:CRMA
   rdf:type gsgu:Member ;
@@ -752,10 +752,10 @@ bln:CRMA
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Rupelian"@en ;
-      gsoc:directTemporalOccupies gst:RupelianAge ;
+      gsoc:occupiesTimeDirectly gst:RupelianAge ;
     ] ;
   gsrl:overlies bln:HM ;
-  gsoq:indirectTemporalOccupies gst:RupelianAge ;
+  gsoc:occupiesTimeIndirectly gst:RupelianAge ;
 .
 bln:EA
   rdf:type gsgu:Formation ;
@@ -833,10 +833,10 @@ bln:EA
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Lutetian"@en ;
-      gsoc:directTemporalOccupies gst:LutetianAge ;
+      gsoc:occupiesTimeDirectly gst:LutetianAge ;
     ] ;
   gsrl:overlies bln:WTT ;
-  gsoq:indirectTemporalOccupies gst:LutetianAge ;
+  gsoc:occupiesTimeIndirectly gst:LutetianAge ;
 .
 bln:FISH
   rdf:type gsgu:Member ;
@@ -891,10 +891,10 @@ bln:FISH
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:LAFM ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:HEHI
   rdf:type gsgu:Formation ;
@@ -975,10 +975,10 @@ bln:HEHI
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:BECS ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:HM
   rdf:type gsgu:Member ;
@@ -1046,10 +1046,10 @@ bln:HM
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Rupelian"@en ;
-      gsoc:directTemporalOccupies gst:RupelianAge ;
+      gsoc:occupiesTimeDirectly gst:RupelianAge ;
     ] ;
   gsrl:overlies bln:BMBG ;
-  gsoq:indirectTemporalOccupies gst:RupelianAge ;
+  gsoc:occupiesTimeIndirectly gst:RupelianAge ;
 .
 bln:HWH
   rdf:type gsgu:Formation ;
@@ -1107,10 +1107,10 @@ bln:HWH
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Ypresian"@en ;
-      gsoc:directTemporalOccupies gst:YpresianAge ;
+      gsoc:occupiesTimeDirectly gst:YpresianAge ;
     ] ;
   gsrl:overlies bln:RB ;
-  gsoq:indirectTemporalOccupies gst:YpresianAge ;
+  gsoc:occupiesTimeIndirectly gst:YpresianAge ;
 .
 bln:LAFM
   rdf:type gsgu:Member ;
@@ -1177,10 +1177,10 @@ bln:LAFM
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:CLEN ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:LC
   rdf:type gsgu:Formation ;
@@ -1283,10 +1283,10 @@ bln:LC
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Ypresian"@en ;
-      gsoc:directTemporalOccupies gst:YpresianAge ;
+      gsoc:occupiesTimeDirectly gst:YpresianAge ;
     ] ;
   gsrl:overlies bln:HWH ;
-  gsoq:indirectTemporalOccupies gst:YpresianAge ;
+  gsoc:occupiesTimeIndirectly gst:YpresianAge ;
 .
 bln:MARF
   rdf:type gsgu:Formation ;
@@ -1367,10 +1367,10 @@ bln:MARF
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Lutetian"@en ;
-      gsoc:directTemporalOccupies gst:LutetianAge ;
+      gsoc:occupiesTimeDirectly gst:LutetianAge ;
     ] ;
   gsrl:overlies bln:EA ;
-  gsoq:indirectTemporalOccupies gst:LutetianAge ;
+  gsoc:occupiesTimeIndirectly gst:LutetianAge ;
 .
 bln:OSB
   rdf:type gsgu:Member ;
@@ -1426,10 +1426,10 @@ bln:OSB
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:FISH ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:POWH
   rdf:type gsgu:Member ;
@@ -1492,10 +1492,10 @@ bln:POWH
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Ypresian"@en ;
-      gsoc:directTemporalOccupies gst:YpresianAge ;
+      gsoc:occupiesTimeDirectly gst:YpresianAge ;
     ] ;
   gsrl:overlies bln:LC ;
-  gsoq:indirectTemporalOccupies gst:YpresianAge ;
+  gsoc:occupiesTimeIndirectly gst:YpresianAge ;
 .
 bln:SEAB
   rdf:type gsgu:Member ;
@@ -1574,10 +1574,10 @@ bln:SEAB
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:OSB ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:SLSY
   rdf:type gsgu:Formation ;
@@ -1644,10 +1644,10 @@ bln:SLSY
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Lutetian"@en ;
-      gsoc:directTemporalOccupies gst:LutetianAge ;
+      gsoc:occupiesTimeDirectly gst:LutetianAge ;
     ] ;
   gsrl:overlies bln:MARF ;
-  gsoq:indirectTemporalOccupies gst:LutetianAge ;
+  gsoc:occupiesTimeIndirectly gst:LutetianAge ;
 .
 bln:SOLT
   rdf:type gsgu:Group ;
@@ -1715,10 +1715,10 @@ bln:SOLT
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:BA ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:THAM
   rdf:type gsgu:Group ;
@@ -1775,10 +1775,10 @@ bln:THAM
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Ypresian"@en ;
-      gsoc:directTemporalOccupies gst:YpresianAge ;
+      gsoc:occupiesTimeDirectly gst:YpresianAge ;
     ] ;
   gsrl:overlies bln:LMBE ;
-  gsoq:indirectTemporalOccupies gst:YpresianAge ;
+  gsoc:occupiesTimeIndirectly gst:YpresianAge ;
 .
 bln:TOTB
   rdf:type gsgu:Member ;
@@ -1846,10 +1846,10 @@ bln:TOTB
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Priabonian"@en ;
-      gsoc:directTemporalOccupies gst:PriabonianAge ;
+      gsoc:occupiesTimeDirectly gst:PriabonianAge ;
     ] ;
   gsrl:overlies bln:BECS ;
-  gsoq:indirectTemporalOccupies gst:PriabonianAge ;
+  gsoc:occupiesTimeIndirectly gst:PriabonianAge ;
 .
 bln:WTT
   rdf:type gsgu:Formation ;
@@ -1954,10 +1954,10 @@ bln:WTT
   gsoc:isParticipantIn [
       rdf:type gspr:Deposition ;
       rdfs:label "Deposition during Ypresian"@en ;
-      gsoc:directTemporalOccupies gst:YpresianAge ;
+      gsoc:occupiesTimeDirectly gst:YpresianAge ;
     ] ;
   gsrl:overlies bln:LC ;
-  gsoq:indirectTemporalOccupies gst:YpresianAge ;
+  gsoc:occupiesTimeIndirectly gst:YpresianAge ;
 .
 gsoc:stephen_richard
   rdf:type owl:NamedIndividual ;


### PR DESCRIPTION
Seems an older version of these properties, and an incorrect prefix, are currently in the e.g. file