### PR TITLE
New GSO-GSRM module with mindat ids

### DIFF
--- a/Loop3D-GSO/Modules/GSO-Geologic_Rock_Material.ttl
+++ b/Loop3D-GSO/Modules/GSO-Geologic_Rock_Material.ttl
@@ -16,2402 +16,2305 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix gsmin: <https://w3id.org/gso/mineral/> .
 
-gsoc:boyan_brodaric
-  rdf:type owl:NamedIndividual ;
-  rdf:type schema:Person ;
-  rdfs:comment "e-mail: mailto:boyan.brodaric@canada.ca " ;
-  rdfs:label "Dr. Boyan Brodaric" ;
-  schema:affiliation "Natural Resources Canada, Geological Survey of Canada" ;
-  schema:identifier <https://orcid.org/0000-0002-7987-3810> ;
-  schema:name "Dr. Boyan Brodaric" ;
-.
-gsoc:stephen_richard
-  rdf:type owl:NamedIndividual ;
-  rdf:type schema:Person ;
-  rdfs:comment "e-mail: mailto:smrTucson@gmail.com " ;
-  rdfs:label "Dr. Stephen M. Richard" ;
-  schema:identifier <https://orcid.org/0000-0001-6041-5302> ;
-  schema:name "Dr. Stephen M. Richard" ;
-.
-gsrm:Acidic_Igneous_Material
-  rdf:type owl:Class ;
-  dct:source "after LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous material with more than 63 percent SiO2."@en ;
-  rdfs:label "acidic igneous material"@en ;
-  rdfs:subClassOf gsrm:Igneous_Material ;
-.
-gsrm:Acidic_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "after LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous rock with more than 63 percent SiO2."@en ;
-  rdfs:label "acidic igneous rock"@en ;
-  rdfs:subClassOf gsrm:Acidic_Igneous_Material ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Alkali-Olivine_Basalt
-  rdf:type owl:Class ;
-  dct:source "http://en.wikipedia.org/wiki/Basalt; Carmichael, I.S. Turner, F.J., Verhoogen, John, 1974, Igneous petrology: New York, McGraw HIll Book Co., p.42-43."@en ;
-  rdfs:comment "Alkali olivine basalt is silica-undersaturated, characterized by the absence of orthopyroxene, absence of quartz, presence of olivine, and typically contains some feldspathoid mineral, alkali feldspar or phlogopite in the groundmass. Feldspar phenocrysts typically are labradorite to andesine in composition. Augite is rich in titanium compared to augite in tholeiitic basalt. Alkali olivine basalt is relatively rich in sodium."@en ;
-  rdfs:comment "The definition of tholeiite and alkali basalt here are more prescriptive than those found in most reference authorities. This is to actually provide some descriptive criteria to allow assignment of rocks on a hand sample basis to the tholeiite or alkali basalt categories if detailed petrographic or chemical data are available."@en ;
-  rdfs:label "alkali olivine basalt"@en ;
-  rdfs:subClassOf gsrm:Basalt ;
-.
-gsrm:Alkali_Feldspar_Granite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Granitic rock that has a plagioclase to total feldspar ratio less than 0.1. QAPF field 2."@en ;
-  rdfs:label "alkali feldspar granite"@en ;
-  rdfs:subClassOf gsrm:Granitoid ;
-.
-gsrm:Alkali_Feldspar_Rhyolite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Rhyolitoid in which the ratio of plagioclase to total feldspar is less than 0.1. QAPF field 2."@en ;
-  rdfs:label "alkali feldspar rhyolite"@en ;
-  rdfs:subClassOf gsrm:Rhyolitoid ;
-.
-gsrm:Alkali_Feldspar_Syenite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Alkali feldspar syenitic rock that contains 0-5 percent quartz and no feldspathoid in the QAPF fraction. QAPF field 6."@en ;
-  rdfs:label "alkali feldspar syenite"@en ;
-  rdfs:subClassOf gsrm:Alkali_Feldspar_Syenitic_Rock ;
-.
-gsrm:Alkali_Feldspar_Syenitic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Syenitoid with a plagioclase to total feldspar ratio of less than 0.1. QAPF fields 6, 6*, and 6'."@en ;
-  rdfs:label "alkali feldspar syenitic rock"@en ;
-  rdfs:subClassOf gsrm:Syenitoid ;
-.
-gsrm:Alkali_Feldspar_Trachyte
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Trachytoid that has a plagioclase to total feldspar ratio less than 0.1, between 0 and 5 percent quartz in the QAPF fraction, and no feldspathoid minerals. QAPF field 6."@en ;
-  rdfs:label "alkali feldspar trachyte"@en ;
-  rdfs:subClassOf gsrm:Alkali_Feldspar_Trachytic_Rock ;
-.
-gsrm:Alkali_Feldspar_Trachytic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Trachytoid that has a plagioclase to total feldspar ratio less than 0.1. QAPF fields 6, 6', and 6*."@en ;
-  rdfs:label "alkali feldspar trachytic rock"@en ;
-  rdfs:subClassOf gsrm:Trachytoid ;
-.
-gsrm:Amphibolite
-  rdf:type owl:Class ;
-  dct:source "Coutinho et al. 2007, IUGS SCMR chapter 8 (http://www.bgs.ac.uk/SCMR/)"@en ;
-  rdfs:comment "Metamorphic rock mainly consisting of green, brown or black amphibole and plagioclase (including albite), which combined form 75 percent or more of the rock, and both of which are present as major constituents. The amphibole constitutes 50 percent or more of the total mafic constituents and is present in an amount of 30 percent or more; other common minerals include quartz, clinopyroxene, garnet, epidote-group minerals, biotite, titanite and scapolite."@en ;
-  rdfs:label "amphibolite"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Andesite
-  rdf:type owl:Class ;
-  dct:source "after LeMaitre et al. 2002"@en ;
-  rdfs:comment "Fine-grained igneous rock with less than 20 percent quartz and less than 10 percent feldspathoid minerals in the QAPF fraction, in which the ratio of plagioclase to total feldspar is greater 0.65. Includes rocks defined modally in QAPF fields 9 and 10 or chemically in TAS field O2 as andesite. Basalt and andesite, which share the same QAPF fields, are distinguished chemically based on silica content, with basalt defined to contain less than 52 weight percent silica. If chemical data are not available, the color index is used to distinguish the categories, with basalt defined to contain greater than 35 percent mafic minerals by volume or greater than 40 percent mafic minerals by weight. Typically consists of plagioclase (frequently zoned from labradorite to oligoclase), pyroxene, hornblende and/or biotite. Fine grained equivalent of dioritic rock."@en ;
-  rdfs:comment "Note the mela-andesite and leuco-basalt categories are not recommended in this system. If chemical analytical data are available to constrain the silica content, the basalt or andesite category should be used."@en ;
-  rdfs:label "andesite"@en ;
-  rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Intermediate_Composition_Igneous_Rock ;
-.
-gsrm:Anorthosite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Anorthositic rock that contains between 0 and 5 percent quartz and no feldspathoid mineral in the QAPF fraction. QAPF field 10."@en ;
-  rdfs:label "anorthosite"@en ;
-  rdfs:subClassOf gsrm:Anorthositic_Rock ;
-.
-gsrm:Anorthositic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002; This vocabulary"@en ;
-  rdfs:comment "Anorthositic rock term invented to label the combined QAPF fields 10, 10*, and 10', in order to construct hierarchy in this vocabulary."@en ;
-  rdfs:comment "Leucocratic phaneritic crystalline igneous rock consisting essentially of plagioclase, often with small amounts of pyroxene. By definition, colour index M is less than 10, and plagiclase to total feldspar ratio is greater than 0.9. Less than 20 percent quartz and less than 10 percent feldspathoid in the QAPF fraction. QAPF field 10, 10*, and 10'."@en ;
-  rdfs:label "anorthositic rock"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Anthracite_Coal
-  rdf:type owl:Class ;
-  dct:source "Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp; see also Neuendorf et al. 2005; http://en.wikipedia.org/wiki/Coal#Types_of_coal; Eberhard Lindner; Chemie für Ingenieure; Lindner Verlag Karlsruhe, S. 258"@en ;
-  rdfs:comment "Coal that has vitrinite mean random reflectance greater than 2.0% (determined in conformance with ISO 7404-5). Less than 12-14 percent volatiles (dry, ash free), greater than 91 percent fixed carbon (dry, ash free basis). The highest rank coal; very hard, glossy, black, with semimetallic luster, semi conchoidal fracture."@en ;
-  rdfs:label "anthracite"@en ;
-  rdfs:label "anthrazit"@de ;
-  rdfs:subClassOf gsrm:Coal ;
-  skos:altLabel "High rank coal"@en ;
-.
-gsrm:Anthropogenic_Material
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Material known to have artificial (human-related) origin; insufficient information to classify in more detail."@en ;
-  rdfs:label "anthropogenic material"@en ;
-  rdfs:subClassOf gsog:Rock_Material ;
-.
-gsrm:Anthropogenic_Unconsolidated_Material
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Unconsolidated material known to have artificial (human-related) origin."@en ;
-  rdfs:label "anthropogenic unconsolidated material"@en ;
-  rdfs:subClassOf gsrm:Anthropogenic_Material ;
-  rdfs:subClassOf gsrm:Unconsolidated_Material ;
-.
-gsrm:Aphanite
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Rock that is too fine grained to categorize in more detail."@en ;
-  rdfs:label "aphanite"@en ;
-  rdfs:subClassOf gsrm:Rock ;
-.
-gsrm:Aplite
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005"@en ;
-  rdfs:comment "Light coloured crystalline rock, characterized by a fine grained allotriomorphic-granular (aplitic, saccharoidal or xenomorphic) texture; typically granitic composition, consisting of quartz, alkali feldspar and sodic plagioclase."@en ;
-  rdfs:label "aplite"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Arenite
-  rdf:type owl:Class ;
-  dct:source "Pettijohn, Potter, Siever, 1972, Sand and Sandstone: New York, Springer Verlag, 681 p."@en ;
-  rdfs:comment "Clastic sandstone that contains less than 10 percent matrix. Matrix is mud-size silicate minerals (clay, feldspar, quartz, rock fragments, and alteration products) of detrital or diagenetic nature."@en ;
-  rdfs:label "arenit"@de ;
-  rdfs:label "arenite"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sandstone ;
-.
-gsrm:Argillite
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al, 2004, provisional SMR 2020-06-11"@en ;
-  rdfs:comment "A weakly metamorphosed argillaceous rock (Flawn, 1953, AAPG Bull v37 p.563-664).  Rock is very fine-grained to aphanitic, compact, indurated, and massive (lacks fissility or cleavage) (Neuendorf et al, 2004). Claystone and Siltstone are related, non-metamorphosed sedimentary rocks. Like Aphanite but sedimentary protolith is determined. In contact metamorphic environments would be Hornfels."@en ;
-  rdfs:label "Argillite "@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Ash_And_Lapilli
-  rdf:type owl:Class ;
-  dct:source "Schmid 1981; LeMaitre et al. 2002"@en ;
-  rdfs:comment "Tephra in which less than 25 percent of fragments are greater than 64 mm in longest dimension"@en ;
-  rdfs:label "ash and lapilli"@en ;
-  rdfs:subClassOf gsrm:Tephra ;
-.
-gsrm:Ash_Breccia_Bomb_Or_Block_Tephra
-  rdf:type owl:Class ;
-  dct:source "Schmid 1981; LeMaitre et al. 2002"@en ;
-  rdfs:comment "Tephra in which more than 25 percent of particles are greater than 64 mm in largest dimension. Includes ash breccia, bomb tephra and block tephra of Gillespie and Styles (1999)"@en ;
-  rdfs:label "ash breccia bomb or block tephra"@en ;
-  rdfs:subClassOf gsrm:Tephra ;
-.
-gsrm:Ash_Tuff_Lapillistone_And_Lapilli_Tuff
-  rdf:type owl:Class ;
-  dct:source "Schmid 1981; LeMaitre et al. 2002"@en ;
-  rdfs:comment "Pyroclastic rock in which less than 25 percent of rock by volume are more than 64 mm in longest diameter. Includes tuff, lapilli tuff, and lapillistone."@en ;
-  rdfs:label "ash tuff lapillistone and lapilli tuff"@en ;
-  rdfs:subClassOf gsrm:Pyroclastic_Rock ;
-.
-gsrm:Basalt
-  rdf:type owl:Class ;
-  dct:source "after LeMaitre et al. 2002"@en ;
-  rdfs:comment "Fine-grained or porphyritic igneous rock with less than 20 percent quartz, and less than 10 percent feldspathoid minerals, in which the ratio of plagioclase to total feldspar is greater 0.65. Typically composed of calcic plagioclase and clinopyroxene; phenocrysts typically include one or more of calcic plagioclase, clinopyroxene, orthopyroxene, and olivine. Includes rocks defined modally in QAPF fields 9 and 10 or chemically in TAS field B as basalt. Basalt and andesite are distinguished chemically based on silica content, with basalt defined to contain less than 52 weight percent silica. If chemical data are not available, the color index is used to distinguish the categories, with basalt defined to contain greater than 35 percent mafic minerals by volume or greater than 40 percent mafic minerals by weight."@en ;
-  rdfs:label "basalt"@en ;
-  rdfs:subClassOf gsrm:Basic_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
-.
-gsrm:Basanite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Tephritoid that has a plagioclase to total feldspar ratio greater than 0.9, and contains more than 10 percent normative (CIPW) olivine."@en ;
-  rdfs:label "basanite"@en ;
-  rdfs:subClassOf gsrm:Tephritoid ;
-.
-gsrm:Basanitic_Foidite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Foiditoid that contains less than 90 percent feldspathoid minerals in the QAPF fraction, and has a plagioclase to total feldspar ratio that is greater than 0.5, with greater than 10 percent normative olivine."@en ;
-  rdfs:label "basanitic foidite"@en ;
-  rdfs:subClassOf gsrm:Foiditoid ;
-.
-gsrm:Basic_Igneous_Material
-  rdf:type owl:Class ;
-  dct:source "after LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous material with between 45 and 52 percent SiO2."@en ;
-  rdfs:label "basic igneous material"@en ;
-  rdfs:subClassOf gsrm:Igneous_Material ;
-.
-gsrm:Basic_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "after LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous rock with between 45 and 52 percent SiO2."@en ;
-  rdfs:label "basic igneous rock"@en ;
-  rdfs:subClassOf gsrm:Basic_Igneous_Material ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Biogenic_Sediment
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Corresponding biogenic sedimentary material and biogenic sedimentary rock categories are not included based on the interpretation that biogenic sedimentary rock will be in a different category, e.g. carbonate sedimentary rock or organic rich sedimentary rock."@en ;
-  rdfs:comment "Sediment composed of greater than 50 percent material of biogenic origin. Because the biogenic material may be skeletal remains that are not organic, all biogenic sediment is not necessarily organic-rich."@en ;
-  rdfs:label "biogenic sediment"@en ;
-  rdfs:subClassOf gsrm:Sediment ;
-.
-gsrm:Biogenic_Silica_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "based on NADM SLTT sedimentary; Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Sedimentary rock that consists of at least 50 percent silicate mineral material, deposited directly by biological processes at the depositional surface, or in particles formed by biological processes within the basin of deposition. Includes radiolarian chert, diatomite, novaculite."@en ;
-  rdfs:label "biogenic silica sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Non_Clastic_Siliceous_Sedimentary_Rock ;
-.
-gsrm:Bituminous_Coal
-  rdf:type owl:Class ;
-  dct:source "Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp; see also http://en.wikipedia.org/wiki/Coal#Types_of_coal; Eberhard Lindner; Chemie für Ingenieure; Lindner Verlag Karlsruhe, S. 258"@en ;
-  rdfs:comment "Coal that has vitrinite mean random reflectance greater than 0.6% and less than 2.0% (determined in conformance with ISO 7404-5), or has a gross calorific value greater than 24 MJ/kg (determined in conformance with ISO 1928). Hard, black, organic rich sedimentary rock; contains less than 91 percent fixed carbon on a dry, mineral-matter-free basis, and greater than 13-14 percent volatiles (dry, ash free). Formed from the compaction or induration of variously altered plant remains similar to those of peaty deposits."@en ;
-  rdfs:label "bituminous coal"@en ;
-  rdfs:subClassOf gsrm:Coal ;
-  skos:altLabel "medium rank coal"@en ;
-.
-gsrm:Boninite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "andesitic rock that contains more than 8 percent MgO. Typically consists of phenocrysts of protoenstatite, orthopyroxene, clinopyroxene, and olivine in a glassy base full of crystallites, and exhibits textures characterisitc of rapid crystal growth."@en ;
-  rdfs:label "boninite"@en ;
-  rdfs:subClassOf gsrm:Andesite ;
-  rdfs:subClassOf gsrm:High_Magnesium_Fine_Grained_Igneous_Rock ;
-.
-gsrm:Boulder_Gravel_Size_Sediment
-  rdf:type owl:Class ;
-  dct:source "Wentworth size scale"@en ;
-  rdfs:comment "Sediment containing greater than 30 percent boulder-size particles (greater than 256 mm in diameter)"@en ;
-  rdfs:label "boulder gravel size sediment"@en ;
-  rdfs:subClassOf gsrm:Gravel_Size_Sediment ;
-.
-gsrm:Boundstone
-  rdf:type owl:Class ;
-  dct:source "Hallsworth and Knox 1999; SLTTs 2004"@en ;
-  rdfs:comment "Sedimentary carbonate rock with preserved biogenic texture, whose original components were bound and encrusted together during deposition by the action of plants and animals during deposition, and remained substantially in the position of growth."@en ;
-  rdfs:label "boundstone"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-.
-gsrm:Breccia
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005"@en ;
-  rdfs:comment "Coarse-grained material composed of angular broken rock fragments; the fragments typically have sharp edges and unworn corners. The fragments may be held together by a mineral cement or in a fine-grained matrix, and consolidated or nonconsolidated. Clasts may be of any composition or origin. In sedimentary environments, breccia is used for material that consists entirely of angular fragments, mostly derived from a single source rock body, as in a rock avalanche deposit, and matrix is interpreted to be the product of comminution of clasts during transport. Diamictite or diamicton is used when the material reflects mixing of rock from a variety of sources, some sub angular or subrounded clasts may be present, and matrix is pre-existing fine grained material that is not a direct product of the brecciation/deposition process."@en ;
-  rdfs:label "breccia"@en ;
-  rdfs:subClassOf gsog:Rock_Material ;
-.
-gsrm:Calcareous_Carbonate_Sediment
-  rdf:type owl:Class ;
-  dct:source "after Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Carbonate sediment with a calcite (plus aragonite) to dolomite ratio greater than 1 to 1. Includes lime-sediments."@en ;
-  rdfs:label "calcareous carbonate sediment"@en ;
-  rdfs:subClassOf gsrm:Calcareous_Carbonate_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Carbonate_Sediment ;
-.
-gsrm:Calcareous_Carbonate_Sedimentary_Material
-  rdf:type owl:Class ;
-  dct:source "after Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Carbonate sedimentary material of unspecified consolidation state with a calcite (plus aragonite) to dolomite ratio greater than 1 to 1. Includes lime-sediments, limestone and dolomitic limestone."@en ;
-  rdfs:label "calcareous carbonate sedimentary material"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Material ;
-.
-gsrm:Calcareous_Carbonate_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004; Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Carbonate sedimentary rock with a calcite (plus aragonite) to dolomite ratio greater than 1 to 1. Includes limestone and dolomitic limestone."@en ;
-  rdfs:label "calcareous carbonate sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Calcareous_Carbonate_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-.
-gsrm:Carbonate_Mud
-  rdf:type owl:Class ;
-  dct:source "follow pattern used for clastic sand and mud categories, based on SLTTs 2004"@en ;
-  rdfs:comment "Carbonate sediment composed of less than 25 percent clasts that have a maximum diameter more than 2 mm, and the ratio of sand size to mud size clasts is less than one."@en ;
-  rdfs:label "carbonate mud"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sediment ;
-  rdfs:subClassOf gsrm:Mud_Size_Sediment ;
-  skos:altLabel "marl"@en ;
-.
-gsrm:Carbonate_Mudstone
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Mudstone that consists of greater than 50 percent carbonate minerals of any origin in the mud size fraction."@en ;
-  rdfs:comment "Not a subcategory of carbonate sedimentary rock because definition does not specify 'carbonate minerals of intrabasinal origin', but is agnostic on origin of carbonate. Schnurrenberger et al. 2003 point out that it is very difficult (at least in lacustrine rocks) to distinguish chemically precipitated or diagenetic carbonate from primary biogenic carbonate. This distinction between biogenic, detrital, and pedogenic or authigenic carbonate material is thus not a good one to use in a general purpose classification system. Schnurrenberger, D., Russell, J. and Kelts, K., 2003, Classification of lacustrine sediments based on sedimentary components: Journal of Paleolimnology, v.29, p141-154."@en ;
-  rdfs:label "carbonate mudstone"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-  rdfs:subClassOf gsrm:Generic_Mudstone ;
-  skos:altLabel "marlstone"@en ;
-.
-gsrm:Carbonate_Ooze
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "ooze that consists of more than 50 percent carbonate skeletal remains"@en ;
-  rdfs:label "carbonate ooze"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Mud ;
-  rdfs:subClassOf gsrm:Ooze ;
-.
-gsrm:Carbonate_Rich_Mud
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Mud size sediment that contains between 10 and 50 percent carbonate minerals in any size fraction. Carbonate origin is not specified."@en ;
-  rdfs:label "carbonate rich mud"@en ;
-  rdfs:subClassOf gsrm:Mud_Size_Sediment ;
-  skos:altLabel "carbonate rich loess"@en ;
-  skos:altLabel "marl"@en ;
-.
-gsrm:Carbonate_Rich_Mudstone
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Carbonate-rich mudstone' definition limits carbonate to mud-size fraction to avoid overlap with 'impure carbonate sedimentary rock'. If carbonate minerals are in sand or gravel size fractions, use 'impure carbonate sedimentary rock'. The operational test typically used to identify this category is if the rock fizzes when hydrochloric acid is applied. The '10 percent carbonate' criteria is a fuzzy boundary."@en ;
-  rdfs:comment "Mudstone that contains between 10 and 50 percent carbonate minerals in the mud size fraction. Carbonate origin is not specified."@en ;
-  rdfs:label "carbonate rich mudstone"@en ;
-  rdfs:subClassOf gsrm:Generic_Mudstone ;
-  skos:altLabel "marlstone"@en ;
-.
-gsrm:Carbonate_Sediment
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sediment in which at least 50 percent of the primary and/or recrystallized constituents are composed of one (or more) of the carbonate minerals calcite, aragonite and dolomite, in particles of intrabasinal origin."@en ;
-  rdfs:label "carbonate sediment"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sediment ;
-.
-gsrm:Carbonate_Sedimentary_Material
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sedimentary material in which at least 50 percent of the primary and/or recrystallized constituents are composed of one (or more) of the carbonate minerals calcite, aragonite and dolomite, in particles of intrabasinal origin."@en ;
-  rdfs:comment "Should carbonate sedimentary material be considered a kind of chemical sedimentary material? Is biogenic precipitation a chemical sedimentary process?"@en ;
-  rdfs:label "carbonate sedimentary material"@en ;
-  rdfs:subClassOf gsrm:Sedimentary_Material ;
-.
-gsrm:Carbonate_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Particularly for fine-grained sedimentary rocks, distinction of 'intrabasinal' versus 'clastic' genesis can be very interpretive. In practice the use of clastic mudstone terminology as opposed to carbonate mudstone terminology may be dermined by a priori knowledge about the rock being categorized. If it is associated with other clastic rocks, the clastic categories will be favored, if with cabonate rocks, the carbonate categories will be favored. Carbonate rock subcatgories are defined on two orthogonal dimensions--mineralogy (calcitic vs. dolomitic vs non-carbonate impurities), and texture. The texture categories used here are those of Dunham (1962), and involve grain size (matrix vs. grains/allochems), fabric (matrix vs. grain supported), and genesis (bound, frame, or fragmental). The textural approach used for carbonate rocks is conceptually incompatible with that used for clastic sedimentary rocks, which is solely grain size or mineralogy based. This leads to problems in the vocabulary for rocks of mixed siliclastic/carbonate mineralogy (grainstone vs. sandstone, carbonate mudstone vs. carbonate rich mudstone, how to accomodate marlstone...)."@en ;
-  rdfs:comment "Sedimentary rock in which at least 50 percent of the primary and/or recrystallized constituents are composed of one (or more) of the carbonate minerals calcite, aragonite, magnesite or dolomite."@en ;
-  rdfs:label "carbonate sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sedimentary_Rock ;
-.
-gsrm:Carbonate_Wackestone
-  rdf:type owl:Class ;
-  dct:source "Dunham 1962"@en ;
-  rdfs:comment "Carbonate sedimentary rock with discernible mud supported depositional texture and containing greater than 10 percent allochems, and constituent particles are of intrabasinal origin. If particles are not intrabasinal, categorization as a mudstone or wackestone should be considered."@en ;
-  rdfs:label "carbonate wackestone"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-.
-gsrm:Carbonatite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous rock composed of more than 50 percent modal carbonate minerals."@en ;
-  rdfs:label "carbonatite"@en ;
-  rdfs:subClassOf gsrm:Exotic_Composition_Igneous_Rock ;
-.
-gsrm:Cataclasite_Series
-  rdf:type owl:Class ;
-  dct:source "Sibson, 1977; Scholz, 1990; Snoke and Tullis, 1998; Barker, 1998 Appendix II; NADM SLTTm, 2004"@en ;
-  rdfs:comment "Fault-related rock that maintained primary cohesion during deformation, with matrix comprising greater than 10 percent of rock mass; matrix is fine-grained material formed through grain size reduction by fracture as opposed to crystal plastic process that operate in mylonitic rock. Includes cataclasite, protocataclasite and ultracataclasite."@en ;
-  rdfs:label "cataclasite series"@en ;
-  rdfs:subClassOf gsrm:Composite_Genesis_Rock ;
-  rdfs:subClassOf gsrm:fault_related_material ;
-.
-gsrm:Chalk
-  rdf:type owl:Class ;
-  dct:source "http://en.wikipedia.org/wiki/Chalk; C.S. Harris, 2009, unpublished web page, http://www.geologyshop.co.uk/chalk.htm"@en ;
-  rdfs:comment "A generally soft, white, very fine-grained, extremely pure, porous limestone. It forms under marine conditions from the gradual accumulation of skeletal elements from minute planktonic green algae (cocoliths), associated with varying proportions of larger microscopic fragments of bivalves, foraminifera and ostracods. It is common to find flint and chert nodules embedded in chalk."@en ;
-  rdfs:label "chalk"@en ;
-  rdfs:subClassOf gsrm:Limestone ;
-.
-gsrm:Chemical_Sedimentary_Material
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sedimentary material that consists of at least 50 percent material produced by inorganic chemical processes within the basin of deposition. Includes inorganic siliceous, carbonate, evaporite, iron-rich, and phosphatic sediment classes."@en ;
-  rdfs:label "chemical sedimentary material"@en ;
-  rdfs:subClassOf gsrm:Sedimentary_Material ;
-.
-gsrm:Chlorite_Actinolite_Epidote_Metamorphic_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Metamorphic rock characterized by 50 percent or more of combined chlorite, actinolite and epidote. Category for rocks generally named greenschist or greenstone."@en ;
-  rdfs:comment "Rock classified as Greenschist is difficult to categorize in the CGI SimpleLithology scheme. This stems in part from the variation in usage and the general fuzzy definition of the term. The definition of greenschist is generally something along the lines of 'metamorphosed rock with a greenish colour, characterized by the presence of actinolite, chlorite and epidote, and containing a planar or linear fabric. The presence or absence of schistose fabric in rocks called 'greenschist' is problematic. The fabric present in many rocks called greenschist is too weak or variably developed to meet the definition of 'schist' per CGI SimpleLithology. Generally if the rock has achieved metamorphic grade such that the term 'gneiss' is applicable, it would not be called greenschist. Thus, 'greenschist' would correspond most closely to a chlorite + actinolite rich 'Foliated metamorphic rock', but if it actually meets the definition of 'Schist' it would be a chlorite + actinolite 'Schist'."@en ;
-  rdfs:label "chlorite actinolite epidote metamorphic rock"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Clastic_Conglomerate
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005; SLTTs 2004"@en ;
-  rdfs:comment "Clastic sedimentary rock composed of at least 30 percent rounded to subangular fragments larger than 2 mm in diameter; typically contains finer grained material in interstices between larger fragments. If more than 15 percent of the fine grained matrix is of indeterminant clastic or diagenetic origin and the fabric is matrix supported, may also be categorized as wackestone. If rock has unsorted or poorly sorted texture with a wide range of particle sizes, may also be categorized as diamictite."@en ;
-  rdfs:comment "Note this category is equivlanet to category labeled 'Conglomeratic rock in SLTTs (2004), not to the category labeled 'Conglomerate' in that system."@en ;
-  rdfs:label "conglomerate"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sedimentary_Rock ;
-  rdfs:subClassOf gsrm:Generic_Conglomerate ;
-  skos:altLabel "conglomeratic rock"@en ;
-.
-gsrm:Clastic_Mudstone
-  rdf:type owl:Class ;
-  dct:source "Pettijohn et al. 1987 referenced in Hallsworth and Knox 1999."@en ;
-  rdfs:comment "Clastic sedimentary rock consisting of less than 30 percent gravel-size (2 mm) particles and with a mud to sand ratio greater than 1."@en ;
-  rdfs:comment "Distinction of intrabasinal, diagenetic, or clastic genesis for very fine-grained carbonate minerals is interpretive in many cases. If there is uncertainty on the mudstone category based on intrabasinal vs epiclastic distinction required for clastic sedimentary rock-carbonate sedimentary rock categorization in this system, it is recommended to use the generic_mudstone category. This category is the union of the various fields labeled 'mudstone' with various qualifiers in Folk, 1954, Figure 1a, although Folk's (1954) category labeled 'mudstone' is a much more restricted category. The CGI category is equivalent to category labeled 'Mudrock' in SLTTs (2004), not to the category labeled 'Mudstone' adopted by that system from Folk (1954). Schnurrenberger, D., Russell, J. and Kelts, K., 2003, Classification of lacustrine sediments based on sedimentary components: Journal of Paleolimnology, v.29, p141-154."@en ;
-  rdfs:label "mudstone"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sedimentary_Rock ;
-  rdfs:subClassOf gsrm:Generic_Mudstone ;
-  skos:altLabel "clastic mudstone"@en ;
-  skos:altLabel "mudrock"@en ;
-.
-gsrm:Clastic_Sandstone
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004; Neuendorf et al. 2005; particle size from Wentworth grade scale"@en ;
-  rdfs:comment "Clastic sedimentary rock in which less than 30 percent of particles are greater than 2 mm in diameter (gravel) and the sand to mud ratio is at least 1."@en ;
-  rdfs:comment "Note this category is equivalent to cagetory labeled 'sandy rock' in SLTTs (2004), not to the much more restricted category labeled 'Sandstone' in that system."@en ;
-  rdfs:label "sandstone"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sedimentary_Rock ;
-  rdfs:subClassOf gsrm:Generic_Sandstone ;
-  skos:altLabel "clastic sandstone"@en ;
-  skos:altLabel "sandy rock"@en ;
-.
-gsrm:Clastic_Sediment
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004; Neuendorf et al. 2005"@en ;
-  rdfs:comment "Choice of 'clastic' is purposful. Other suggested labels for this category include siliciclastic and terrigineous clastic. Siliciclastic is considered too limiting because the category includes rocks that consists clasts of carbonate minerals, e.g. epiclastic detritus eroded from carbonate rock. Terrigineous clastic was considered and rejected first because it is considered redundant, anything that is terrigineous is clastic. Second, it is questionable if clastic sediment derived by submarine processes (fragementation by gravity sliding, faulting, or volcanic activity, with transport by sediment gravity flow or submarine currents) is terrigineous, but it is clastic and is meant to be included in this category."@en ;
-  rdfs:comment "Sediment in which at least 50 percent of the constituent particles were derived from erosion, weathering, or mass-wasting of pre-existing earth materials, and transported to the place of deposition by mechanical agents such as water, wind, ice and gravity."@en ;
-  rdfs:label "clastic sediment"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sediment ;
-.
-gsrm:Clastic_Sedimentary_Material
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004; Neuendorf et al. 2005"@en ;
-  rdfs:comment "Sedimentary material of unspecified consolidation state in which at least 50 percent of the constituent particles were derived from erosion, weathering, or mass-wasting of pre-existing earth materials, and transported to the place of deposition by mechanical agents such as water, wind, ice and gravity."@en ;
-  rdfs:label "clastic sedimentary material"@en ;
-  rdfs:subClassOf gsrm:Sedimentary_Material ;
-.
-gsrm:Clastic_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004; Neuendorf et al. 2005"@en ;
-  rdfs:comment "Sedimentary rock in which at least 50 percent of the constituent particles were derived from erosion, weathering, or mass-wasting of pre-existing earth materials, and transported to the place of deposition by mechanical agents such as water, wind, ice and gravity."@en ;
-  rdfs:comment "The conglomerate, sandstone, mudstone, and wackestone categories are not defined as kinds of clastic sedimentary rocks because rocks meeting their purely grainsize based definitions might also be iron-rich, phosphatic, or carbonate. This is based on GeoSciML allowance to assign rocks to more than one lithology category. For example to categorize a rock as a clastic conglomerate requires assignment ot the 'clastic sedimentary rock' category and to the 'conglomerate' category. Particularly for fine-grained sedimentary rocks, distinction of 'intrabasinal' versus 'clastic' genesis can be very interpretive. In practice the use of clastic mudstone terminology as opposed to carbonate mudstone terminology may be dermined by a priori knowledge about the rock being categorized. If it is associated with other clastic rocks, the clastic categories will be favored, if with cabonate rocks, the carbonate categories will be favored."@en ;
-  rdfs:label "clastic sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sedimentary_Rock ;
-.
-gsrm:Clay
-  rdf:type owl:Class ;
-  dct:source "based on SLTTs 2004; Neuendorf et al. 2005; particle size from Wentworth grade scale"@en ;
-  rdfs:comment "Mud that consists of greater than 50 percent particles with grain size less than 0.004 mm"@en ;
-  rdfs:label "clay"@en ;
-  rdfs:subClassOf gsrm:Mud ;
-.
-gsrm:Claystone
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Mudstone that contains no detectable silt, inferred to consist virtually entirely of clay-size particles."@en ;
-  rdfs:label "claystone"@en ;
-  rdfs:subClassOf gsrm:Clastic_Mudstone ;
-.
-gsrm:Coal
-  rdf:type owl:Class ;
-  dct:source "Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp."@en ;
-  rdfs:comment "A consolidated organic sedimentary material having less than 75% moisture. This category includes low, medium, and high rank coals according to International Classification of In-Seam Coal (United Nations, 1998), thus including lignite. Sapropelic coal is not distinguished in this category from humic coals. Formed from the compaction or induration of variously altered plant remains similar to those of peaty deposits."@en ;
-  rdfs:label "coal"@en ;
-  rdfs:label "kohle"@de ;
-  rdfs:subClassOf gsrm:Organic_Rich_Sedimentary_Rock ;
-.
-gsrm:Cobble_Gravel_Size_Sediment
-  rdf:type owl:Class ;
-  dct:source "Wentworth size scale"@en ;
-  rdfs:comment "Sediment containing greater than 30 percent cobble-size particles (64-256 mm in diameter)"@en ;
-  rdfs:label "cobble gravel size sediment"@en ;
-  rdfs:subClassOf gsrm:Gravel_Size_Sediment ;
-.
-gsrm:Composite_Genesis_Material
-  rdf:type owl:Class ;
-  dct:source "SLTTm 2004"@en ;
-  rdfs:comment "Material of unspecified consolidation state formed by geological modification of pre-existing materials outside the realm of igneous and sedimentary processes. Includes rocks formed by impact metamorphism, standard dynamothermal metamorphism, brittle deformation, weathering, metasomatism and hydrothermal alteration (diagenesis is a sedimentary process in this context)."@en ;
-  rdfs:label "composite genesis material"@en ;
-  rdfs:subClassOf gsog:Rock_Material ;
-.
-gsrm:Composite_Genesis_Rock
-  rdf:type owl:Class ;
-  dct:source "SLTTm 2004"@en ;
-  rdfs:comment "Rock formed by geological modification of pre-existing rocks outside the realm of igneous and sedimentary processes. Includes rocks formed by impact metamorphism, standard dynamothermal metamorphism, brittle deformation, weathering, metasomatism and hydrothermal alteration (diagenesis is a sedimentary process in this context)."@en ;
-  rdfs:label "composite genesis rock"@en ;
-  rdfs:subClassOf gsrm:Composite_Genesis_Material ;
-  rdfs:subClassOf gsrm:Rock ;
-.
-gsrm:Consolidation_Degree
-  rdf:type owl:Class ;
-  rdfs:comment "A property that specifies the degree to which an aggregation of EarthMaterial particles is a distinct solid material. Consolidation and induration are related concepts specified by this property. They define a continuum from unconsolidated material to very hard rock. Induration is the degree to which a consolidated material is made hard, operationally determined by how difficult it is to break a piece of the material. Consolidated materials may have varying degrees of induration (NADMSC, 2004)"@en ;
-  rdfs:isDefinedBy "GeoSciML v4"@en ;
-  rdfs:label "Consolidation degree"@en ;
-  rdfs:subClassOf gsoc:Physical_Quality ;
-  rdfs:subClassOf [
-      rdf:type owl:Restriction ;
-      owl:allValuesFrom gsog:Rock_Material ;
-      owl:onProperty gsoc:isQualityOf ;
-    ] ;
-  rdfs:subClassOf [
-      rdf:type owl:Restriction ;
-      owl:onClass gsog:Rock_Material ;
-      owl:onProperty gsoc:isQualityOf ;
-      owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ;
-    ] ;
-.
-gsrm:Consolidation_Degree_Value
-  rdf:type owl:Class ;
-  rdfs:label "Consolidation degree category value"@en ;
-  rdfs:subClassOf gsoc:Named_Value ;
-  rdfs:subClassOf [
-      rdf:type owl:Restriction ;
-      owl:allValuesFrom gsrm:Consolidation_Degree ;
-      owl:onProperty gsoc:isValueOf ;
-    ] ;
-.
-gsrm:Crystalline_Carbonate
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Carbonate rock of indeterminate mineralogy in which diagenetic processes have obliterated any original depositional texture."@en ;
-  rdfs:label "crystalline carbonate"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-.
-gsrm:Dacite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Fine grained or porphyritic crystalline rock that contains less than 90 percent mafic minerals, between 20 and 60 percent quartz in the QAPF fraction, and has a plagioclase to total feldspar ratio greater than 0.65. Includes rocks defined modally in QAPF fields 4 and 5 or chemically in TAS Field O3. Typically composed of quartz and sodic plagioclase with minor amounts of biotite and/or hornblende and/or pyroxene; fine-grained equivalent of granodiorite and tonalite."@en ;
-  rdfs:label "dacite"@en ;
-  rdfs:subClassOf gsrm:Acidic_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
-.
-gsrm:Diamictite
-  rdf:type owl:Class ;
-  dct:source "Fairbridge and Bourgeois 1978"@en ;
-  rdfs:comment "Unsorted or poorly sorted, clastic sedimentary rock with a wide range of particle sizes including a muddy matrix. Biogenic materials that have such texture are excluded. Distinguished from conglomerate, sandstone, mudstone based on polymodality and lack of structures related to transport and deposition of sediment by moving air or water. If more than 10 percent of the fine grained matrix is of indeterminant clastic or diagenetic origin and the fabric is matrix supported, may also be categorized as wacke."@en ;
-  rdfs:label "diamictite"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sedimentary_Rock ;
-.
-gsrm:Diamicton
-  rdf:type owl:Class ;
-  dct:source "Fairbridge and Bourgeois 1978"@en ;
-  rdfs:comment "Unsorted or poorly sorted, clastic sediment with a wide range of particle sizes, including a muddy matrix. Biogenic materials that have such texture are excluded. Distinguished from conglomerate, sandstone, mudstone based on polymodality and lack of structures related to transport and deposition of sediment by moving air or water. Assignment to an other size class can be used in conjunction to indicate the dominant grain size."@en ;
-  rdfs:comment "definition amplified to help distinguish diamicton, conglomerate and wackestone in this version"@en ;
-  rdfs:label "diamicton"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sediment ;
-.
-gsrm:Diorite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline rock consisting of intermediate plagioclase, commonly with hornblende and often with biotite or augite; colour index M less than 90, sodic plagioclase (An0-An50), no feldspathoid, and between 0 and 5 percent quartz. Includes rocks defined modally in QAPF field 10 as diorite."@en ;
-  rdfs:label "diorite"@en ;
-  rdfs:subClassOf gsrm:Dioritic_Rock ;
-.
-gsrm:Dioritic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline rock with M less than 90, consisting of intermediate plagioclase, commonly with hornblende and often with biotite or augite. A dioritoid with a plagioclase to total feldspar ratio (in the QAPF fraction) greater than 0.9. Includes rocks defined modally in QAPF fields 10, 10' and 10*."@en ;
-  rdfs:label "dioritic rock"@en ;
-  rdfs:subClassOf gsrm:Dioritoid ;
-.
-gsrm:Dioritoid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline igneous rock with M less than 90, consisting of intermediate plagioclase, commonly with hornblende and often with biotite or augite. Plagioclase to total feldspar ratio is greater that 0.65, and anorthite content of plagioclase is less than 50 percent. Less than 10 percent feldspathoid mineral and less than 20 percent quartz in the QAPF fraction. Includes rocks defined modally in QAPF fields 9 and 10 (and their subdivisions)."@en ;
-  rdfs:label "dioritoid"@en ;
-  rdfs:subClassOf gsrm:Intermediate_Composition_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Doleritic_Rock
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al 2005; LeMaitre et al. 2002; Gillespie and Styles 1999"@en ;
-  rdfs:comment "Dark colored gabbroic (basaltic) or dioritic (andesitic) rock intermediate in grain size between basalt and gabbro and composed of plagioclase, pyroxene and opaque minerals; often with ophitic texture. Typically occurs as hypabyssal intrusions. Includes dolerite, microdiorite, diabase and microgabbro."@en ;
-  rdfs:label "doleritic rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Dolomitic_Or_Magnesian_Sedimentary_Material
-  rdf:type owl:Class ;
-  dct:source "after SLTTs 2004, Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Carbonate sedimentary material of unspecified consolidation degree with a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1. Includes dolomite sediment, dolostone, lime dolostone and magnesite-stone."@en ;
-  rdfs:label "dolomitic or magnesian sedimentary material"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Material ;
-.
-gsrm:Dolomitic_Or_Magnesian_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "after SLTTs 2004, Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Carbonate sedimentary rock with a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1. Includes dolostone, lime dolostone and magnesite-stone."@en ;
-  rdfs:label "dolomitic or magnesian sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-  rdfs:subClassOf gsrm:Dolomitic_Or_Magnesian_Sedimentary_Material ;
-.
-gsrm:Dolomitic_Sediment
-  rdf:type owl:Class ;
-  dct:source "after SLTTs 2004, Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Carbonate sediment with a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1."@en ;
-  rdfs:label "dolomitic sediment"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sediment ;
-  rdfs:subClassOf gsrm:Dolomitic_Or_Magnesian_Sedimentary_Material ;
-.
-gsrm:Dolostone
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Pure carbonate sedimentary rock with a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1."@en ;
-  rdfs:label "dolomite"@en ;
-  rdfs:subClassOf gsrm:Dolomitic_Or_Magnesian_Sedimentary_Rock ;
-  rdfs:subClassOf gsrm:Pure_Carbonate_Sedimentary_Rock ;
-  skos:altLabel "dolostone"@en ;
-  skos:altLabel "pure dolomitic or magnesian carbonate sedimentary rock"@en ;
-.
-gsrm:Duricrust
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Rock forming a hard crust or layer at or near the Earth's surface at the time of formation, e.g. in the upper horizons of a soil, characterized by structures indicative of pedogenic origin."@en ;
-  rdfs:label "duricrust"@en ;
-  rdfs:subClassOf gsrm:Composite_Genesis_Rock ;
-  rdfs:subClassOf gsrm:material_formed_in_surficial_environment ;
-.
-gsrm:Eclogite
-  rdf:type owl:Class ;
-  dct:source "IUGS SCMR 2007 (http://www.bgs.ac.uk/SCMR/)"@en ;
-  rdfs:comment "Metamorphic rock composed of 75 percent or more (by volume) omphacite and garnet, both of which are present as major constituents, the amount of neither of them being higher than 75 percent (by volume); the presence of plagioclase precludes classification as an eclogite."@en ;
-  rdfs:label "eclogite"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Evaporite
-  rdf:type owl:Class ;
-  dct:source "Jackson 1997; SLTTs 2004"@en ;
-  rdfs:comment "Nonclastic sedimentary rock composed of at least 50 percent non-carbonate salts, including chloride, sulfate or borate minerals; formed through precipitation of mineral salts from a saline solution (non-carbonate salt rock)."@en ;
-  rdfs:label "evaporite"@en ;
-  rdfs:subClassOf gsrm:Chemical_Sedimentary_Material ;
-.
-gsrm:Exotic_Alkaline_Rock
-  rdf:type owl:Class ;
-  dct:source "based on LeMaitre et al. 2002"@en ;
-  rdfs:comment "Kimberlite, lamproite, or lamprophyre. Generally are potassic, mafic or ultramafic rocks. Olivine (commonly serpentinized in kimberlite), and phlogopite are significant constituents."@en ;
-  rdfs:label "exotic alkaline rock"@en ;
-  rdfs:subClassOf gsrm:Exotic_Composition_Igneous_Rock ;
-.
-gsrm:Exotic_Composition_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "Gillespie and Styles 1999; LeMaitre et al. 2002"@en ;
-  rdfs:comment "Rock with 'exotic' mineralogical, textural or field setting characteristics; typically dark colored, with abundant phenocrysts. Criteria include: presence of greater than 10 percent melilite or leucite, or presence of kalsilite, or greater than 50 percent carbonate minerals. Includes Carbonatite, Melilitic rock, Kalsilitic rocks, Kimberlite, Lamproite, Leucitic rock and Lamprophyres."@en ;
-  rdfs:label "exotic composition igneous rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Exotic_Evaporite
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Category represents evaporite material that is not mostly gypsum/anhydrite or halite. These are generally not very common, thus the 'exotic' name"@en ;
-  rdfs:comment "Evaporite that is not 50 percent halite or 50 percent gypsum or anhydrite."@en ;
-  rdfs:label "exotic evaporite"@en ;
-  rdfs:subClassOf gsrm:Evaporite ;
-.
-gsrm:Fine_Grained_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "Gillespie and Styles 1999; LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous rock in which the framework of the rock consists of crystals that are too small to determine mineralogy with the unaided eye; framework may include up to 50 percent glass. A significant percentage of the rock by volume may be phenocrysts. Includes rocks that are generally called volcanic rocks."@en ;
-  rdfs:comment "Need to make decision as to whether devitrified glass should be considered glass or microcrystalline framework for purposes of categorization"@en ;
-  rdfs:label "fine grained igneous rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-  skos:altLabel "volcanic rock"@en ;
-.
-gsrm:Foid_Bearing_Alkali_Feldspar_Syenite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Alkali feldspar syenitic rock that contains 0-10 percent feldspathoid mineral and no quartz in the QAPF fraction. QAPF field 6'."@en ;
-  rdfs:label "foid bearing alkali feldspar syenite"@en ;
-  rdfs:subClassOf gsrm:Alkali_Feldspar_Syenitic_Rock ;
-.
-gsrm:Foid_Bearing_Alkali_Feldspar_Trachyte
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Alkali feldspar trachytic rock that contains no quartz and between 0 and 10 percent feldspathoid mineral in the QAPF fraction. QAPF field 6'."@en ;
-  rdfs:label "foid bearing alkali feldspar trachyte"@en ;
-  rdfs:subClassOf gsrm:Alkali_Feldspar_Trachytic_Rock ;
-.
-gsrm:Foid_Bearing_Anorthosite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Anorthositic rock that contains between 0 and 10 percent feldspathoid mineral and no quartz in the QAPF fraction. QAPF field 10'."@en ;
-  rdfs:label "foid bearing anorthosite"@en ;
-  rdfs:subClassOf gsrm:Anorthositic_Rock ;
-.
-gsrm:Foid_Bearing_Diorite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Dioritic rock that contains between 0 and 10 percent feldspathoid minerals in the QAPF fraction. QAPF field 10'."@en ;
-  rdfs:label "foid bearing diorite"@en ;
-  rdfs:subClassOf gsrm:Dioritic_Rock ;
-.
-gsrm:Foid_Bearing_Gabbro
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Gabbroic rock that contains 0-10 percent feldspathoid minerals and no quartz in the QAPF fraction. QAPF field 10'."@en ;
-  rdfs:label "foid bearing gabbro"@en ;
-  rdfs:subClassOf gsrm:Gabbroic_Rock ;
-.
-gsrm:Foid_Bearing_Latite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Latitic rock that contains no quartz and between 0 and 10 percent feldspathoid minerals in the QAPF fraction. QAPF field 8'."@en ;
-  rdfs:label "foid bearing latite"@en ;
-  rdfs:subClassOf gsrm:Latitic_Rock ;
-.
-gsrm:Foid_Bearing_Monzodiorite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Monzodioritic rock that contains between 0 and 10 percent feldspathoid mineral."@en ;
-  rdfs:label "foid bearing monzodiorite"@en ;
-  rdfs:subClassOf gsrm:Monzodioritic_Rock ;
-.
-gsrm:Foid_Bearing_Monzogabbro
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Monzogabbroic rock that contains 0 to 10 percent feldspathoid mineral in the QAPF fraction. QAPF field 9'."@en ;
-  rdfs:label "foid bearing monzogabbro"@en ;
-  rdfs:subClassOf gsrm:Monzogabbroic_Rock ;
-.
-gsrm:Foid_Bearing_Monzonite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Monzonitic rock that contains 0-10 percent feldspathoid mineral and no quartz in the QAPF fraction. Includes rocks defined modally in QAPF Field 8'."@en ;
-  rdfs:label "foid bearing monzonite"@en ;
-  rdfs:subClassOf gsrm:Monzonitic_Rock ;
-.
-gsrm:Foid_Bearing_Syenite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Syenitic rock that contains between 0 and 10 percent feldspathoid mineral and no quartz in the QAPF fraction. Defined modally in QAPF Field 7'."@en ;
-  rdfs:label "foid bearing syenite"@en ;
-  rdfs:subClassOf gsrm:Syenitic_Rock ;
-.
-gsrm:Foid_Bearing_Trachyte
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Trachytic rock that contains between 0 and 10 percent feldspathoid in the QAPF fraction, and no quartz. QAPF field 7'."@en ;
-  rdfs:label "foid bearing trachyte"@en ;
-  rdfs:subClassOf gsrm:Trachytic_Rock ;
-.
-gsrm:Foid_Diorite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Foid dioritoid in which the plagioclase to total feldspar ratio is greater than 0.9. Includes rocks defined modally in QAPF field 14."@en ;
-  rdfs:label "foid diorite"@en ;
-  rdfs:subClassOf gsrm:Foid_Dioritoid ;
-.
-gsrm:Foid_Dioritoid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline igneous rock in which M is less than 90, the plagioclase to total feldspar ratio is greater than 0.5, feldspathoid minerals form 10-60 percent of the QAPF fraction, plagioclase has anorthite content less than 50 percent. These rocks typically contain large amounts of mafic minerals. Includes rocks defined modally in QAPF fields 13 and 14."@en ;
-  rdfs:label "foid dioritoid"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Foid_Gabbro
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Foid gabbroid that has a plagioclase to total feldspar ratio greater than 0.9. Includes rocks defined modally in QAPF field 14."@en ;
-  rdfs:label "foid gabbro"@en ;
-  rdfs:subClassOf gsrm:Foid_Gabbroid ;
-.
-gsrm:Foid_Gabbroid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline igneous rock in which M is less than 90, the plagioclase to total feldspar ratio is greater than 0.5, feldspathoids form 10-60 percent of the QAPF fraction, and plagioclase has anorthite content greater than 50 percent. These rocks typically contain large amounts of mafic minerals. Includes rocks defined modally in QAPF fields 13 and 14."@en ;
-  rdfs:label "foid gabbroid"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Foid_Monzodiorite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Foid dioritoid in which the plagioclase to total feldspar ratio is between 0.1 and 0.9. Includes rocks defined modally in QAPF field 13."@en ;
-  rdfs:label "foid monzodiorite"@en ;
-  rdfs:subClassOf gsrm:Foid_Dioritoid ;
-.
-gsrm:Foid_Monzogabbro
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Foid gabbroid that has a plagioclase to total feldspar ratio between 0.5 and 0.9. Includes rocks defined modally in QAPF field 13."@en ;
-  rdfs:label "foid monzogabbro"@en ;
-  rdfs:subClassOf gsrm:Foid_Gabbroid ;
-.
-gsrm:Foid_Monzosyenite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Foid syenitoid rock that has a plagioclase to total feldspar ratio of between 0.1 and 0.5. Includes rocks defined modally in QAPF Field 12."@en ;
-  rdfs:label "foid monzosyenite"@en ;
-  rdfs:subClassOf gsrm:Foid_Syenitoid ;
-.
-gsrm:Foid_Syenite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Foid syenitoid that has a plagioclase to total feldspar ratio of less than 0.1. Includes rocks defined modally in QAPF field 11."@en ;
-  rdfs:label "foid syenite"@en ;
-  rdfs:subClassOf gsrm:Foid_Syenitoid ;
-.
-gsrm:Foid_Syenitoid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline igneous rock with M less than 90, contains between 10 and 60 percent feldspathoid mineral in the QAPF fraction, and has a plagioclase to total feldspar ratio less than 0.5. Includes QAPF fields 11 and 12."@en ;
-  rdfs:label "foid syenitoid"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Foidite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Foiditoid that contains greater than 90 percent feldspathoid minerals in the QAPF fraction."@en ;
-  rdfs:label "foidite"@en ;
-  rdfs:subClassOf gsrm:Foiditoid ;
-.
-gsrm:Foiditoid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Fine grained crystalline rock containing less than 90 percent mafic minerals and more than 60 percent feldspathoid minerals in the QAPF fraction. Includes rocks defined modally in QAPF field 15 or chemically in TAS field F."@en ;
-  rdfs:label "foiditoid"@en ;
-  rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
-  skos:altLabel "foidite (sensu lato)"@en ;
-  skos:altLabel "foiditic rock"@en ;
-.
-gsrm:Foidolite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline rock containing more than 60 percent feldspathoid minerals in the QAPF fraction. Includes rocks defined modally in QAPF field 15"@en ;
-  rdfs:label "foidolite"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Foliated_Metamorphic_Rock
-  rdf:type owl:Class ;
-  dct:source "based on NADM SLTT metamorphic"@en ;
-  rdfs:comment "Metamorphic rock in which 10 percent or more of the contained mineral grains are elements in a planar or linear fabric. Cataclastic or glassy character precludes classification with this concept."@en ;
-  rdfs:label "foliated metamorphic rock"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Fragmental_Igneous_Material
-  rdf:type owl:Class ;
-  dct:source "CGI concept definition task group"@en ;
-  rdfs:comment "igneous_material of unspecified consolidation state in which greater than 75 percent of the rock consists of fragments produced as a result of igneous rock-forming process."@en ;
-  rdfs:label "fragmental igneous material"@en ;
-  rdfs:subClassOf gsrm:Igneous_Material ;
-.
-gsrm:Fragmental_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Igneous rock in which greater than 75 percent of the rock consists of fragments produced as a result of igneous rock-forming process. Includes pyroclastic rocks, autobreccia associated with lava flows and intrusive breccias. Excludes deposits reworked by epiclastic processes (see Tuffite)"@en ;
-  rdfs:label "fragmental igneous rock"@en ;
-  rdfs:subClassOf gsrm:Fragmental_Igneous_Material ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Framestone
-  rdf:type owl:Class ;
-  dct:source "Hallsworth and Knox 1999; SLTTs 2004, Table 15-3-1"@en ;
-  rdfs:comment "Carbonate reef rock consisting of a rigid framework of colonies, shells or skeletons, with internal cavities filled with fine sediment; usually created through the activities of colonial organisms."@en ;
-  rdfs:label "framestone"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-.
-gsrm:Gabbro
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Gabbroic rock that contains between 0 and 5 percent quartz and no feldspathoid mineral in the QAPF fraction. Includes rocks defined modally in QAPF Field 10 as gabbro."@en ;
-  rdfs:comment "Note that this category includes gabbro (sensu stricto) of LeMaitre et al. 2002, but is broader, including the other rock types defined by orthopyroxene-clinopyroxene-olivine-hornblende mineral ratios."@en ;
-  rdfs:label "gabbro"@en ;
-  rdfs:subClassOf gsrm:Gabbroic_Rock ;
-.
-gsrm:Gabbroic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Gabbroid that has a plagioclase to total feldspar ratio greater than 0.9 in the QAPF fraction. Includes QAPF fields 10*, 10, and 10'. This category includes the various categories defined in LeMaitre et al. (2002) based on the mafic mineralogy, but apparently not subdivided based on the quartz/feldspathoid content."@en ;
-  rdfs:label "gabbroic rock"@en ;
-  rdfs:subClassOf gsrm:Basic_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Gabbroid ;
-.
-gsrm:Gabbroid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline igneous rock that contains less than 90 percent mafic minerals, and up to 20 percent quartz or up to 10 percent feldspathoid in the QAPF fraction. The ratio of plagioclase to total feldspar is greater than 0.65, and anorthite content of the plagioclase is greater than 50 percent. Includes rocks defined modally in QAPF fields 9 and 10 and their subdivisions."@en ;
-  rdfs:label "gabbroid"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Generic_Conglomerate
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005; SLTTs 2004; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
-  rdfs:comment "Sedimentary rock composed of at least 30 percent rounded to subangular fragments larger than 2 mm in diameter; typically contains finer grained material in interstices between larger fragments. If more than 15 percent of the fine grained matrix is of indeterminant clastic or diagenetic origin and the fabric is matrix supported, may also be categorized as wackestone. If rock has unsorted or poorly sorted texture with a wide range of particle sizes, may also be categorized as diamictite."@en ;
-  rdfs:label "generic conglomerate"@en ;
-  rdfs:subClassOf gsrm:Sedimentary_Rock ;
-.
-gsrm:Generic_Mudstone
-  rdf:type owl:Class ;
-  dct:source "Pettijohn et al. 1987 referenced in Hallsworth and Knox 1999; extrapolated from Folk, 1954, Figure 1a; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
-  rdfs:comment "Distinction of intrabasinal, diagenetic, or clastic genesis for very fine-grained carbonate minerals is so interpretive that it is proposed to not define the mudstone category based on intrabasinal vs epiclastic distinction required for clastic sedimentary rock-carbonate sedimentary rock categorization in this system. Schnurrenberger, D., Russell, J. and Kelts, K., 2003, Classification of lacustrine sediments based on sedimentary components: Journal of Paleolimnology, v.29, p141-154."@en ;
-  rdfs:comment "Sedimentary rock consisting of less than 30 percent gravel-size (2 mm) particles and with a mud to sand ratio greater than 1. Clasts may be of any composition or origin."@en ;
-  rdfs:label "generic mudstone"@en ;
-  rdfs:subClassOf gsrm:Sedimentary_Rock ;
-.
-gsrm:Generic_Sandstone
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004; Neuendorf et al. 2005; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
-  rdfs:comment "Sedimentary rock in which less than 30 percent of particles are greater than 2 mm in diameter (gravel) and the sand to mud ratio is at least 1."@en ;
-  rdfs:label "generic sandstone"@en ;
-  rdfs:subClassOf gsrm:Sedimentary_Rock ;
-.
-gsrm:Glass_Rich_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary, based on Gillespie and Styles 1999"@en ;
-  rdfs:comment "Igneous rock that contains greater than 50 percent massive glass."@en ;
-  rdfs:label "glass rich igneous rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Glassy_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Igneous rock that consists of greater than 80 percent massive glass."@en ;
-  rdfs:comment "Note that this category is used for massive glassy rocks. Much of the pyroclastic material in a pyroclastic rock may be composed of glass, but the rock is named based on its fragmental nature."@en ;
-  rdfs:label "glassy igneous rock"@en ;
-  rdfs:subClassOf gsrm:Glass_Rich_Igneous_Rock ;
-.
-gsrm:Glaucophane_Lawsonite_Epidote_Metamorphic_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "A metamorphic rock of roughly basaltic composition, defined by the presence of glaucophane with lawsonite or epidote. Other minerals that may be present include jadeite, albite, chlorite, garnet, and muscovite (phengitic white mica). Typically fine-grained, dark colored. Category for rocks commonly referred to as blueschist."@en ;
-  rdfs:comment "Fabric is weakly developed in this rock in many cases, so the fabric categories 'foliated metamorphic rock, 'schist' or 'granofels' may apply."@en ;
-  rdfs:label "glaucophane lawsonite epidote metamorphic rock"@en ;
-  rdfs:label "glaukophanschiefer"@de ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-  skos:altLabel "blauschiefer"@de ;
-.
-gsrm:Gneiss
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005"@en ;
-  rdfs:comment "Foliated metamorphic rock with bands or lenticles rich in granular minerals alternating with bands or lenticles rich in minerals with a flaky or elongate prismatic habit. Mylonitic foliation or well developed, continuous schistosity (greater than 50 percent of the rock consists of grains participate in a planar or linear fabric) precludes classification with this concept."@en ;
-  rdfs:label "gneiss"@en ;
-  rdfs:subClassOf gsrm:Foliated_Metamorphic_Rock ;
-.
-gsrm:Grainstone
-  rdf:type owl:Class ;
-  dct:source "Dunham 1962"@en ;
-  rdfs:comment "Carbonate sedimentary rock with recognizable depositional fabric that is grain-supported, and constituent particles are of intrabasinal origin; contains little or no mud matrix. Distinction from sandstone is based on interpretation of intrabasinal origin of clasts and grain-supported fabric, but grainstone definition does not include a grain size criteria."@en ;
-  rdfs:label "grainstone"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-  skos:altLabel "carbonate grainstone"@en ;
-.
-gsrm:Granite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline rock consisting of quartz, alkali feldspar and plagioclase (typically sodic) in variable amounts, usually with biotite and/or hornblende. Includes rocks defined modally in QAPF Field 3."@en ;
-  rdfs:label "granite"@en ;
-  rdfs:subClassOf gsrm:Granitoid ;
-.
-gsrm:Granitoid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline igneous rock consisting of quartz, alkali feldspar and/or plagioclase. Includes rocks defined modally in QAPF fields 2, 3, 4 and 5 as alkali feldspar granite, granite, granodiorite or tonalite."@en ;
-  rdfs:label "granitoid"@en ;
-  rdfs:subClassOf gsrm:Acidic_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-  skos:altLabel "granitic rock"@en ;
-.
-gsrm:Granodiorite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline rock consisting essentially of quartz, sodic plagioclase and lesser amounts of alkali feldspar with minor hornblende and biotite. Includes rocks defined modally in QAPF field 4."@en ;
-  rdfs:label "granodiorite"@en ;
-  rdfs:subClassOf gsrm:Granitoid ;
-.
-gsrm:Granofels
-  rdf:type owl:Class ;
-  dct:source "SLTTm 2004"@en ;
-  rdfs:comment "Metamorphic rock with granoblastic fabric and very little or no foliation (less than 10 percent of the mineral grains in the rock are elements in a planar or linear fabric). Grainsize not specified."@en ;
-  rdfs:label "granofels"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Granulite
-  rdf:type owl:Class ;
-  dct:source "Fettes and Desmons (2007). See also Wimmenauer (1985), Winkler (1979) (D.R. Bowes (1989), The Encyclopedia of Igneous and Metamorphic Petrology; Van Nostrand Reinhold ISBN: 0-442-20623-2 ; wikipedia, http://en.wikipedia.org/wiki/Granulite accessed 5/30/09"@en ;
-  rdfs:comment "Metamorphic rock of high metamorphic grade in which Fe-Mg silicate minerals are dominantly hydroxl-free; feldspar must be present, and muscovite is absent; rock contains less than 90 percent mafic minerals, less than 75 percent calcite and/or dolomite, less than 75 percent quartz, less than 50 percent iron-bearing minerals (hematite, magnetite, limonite-group, siderite, iron-sulfides), and less than 50 percent calc-silicate minerals."@en ;
-  rdfs:comment "Wimmenauer (1985) requires granulite to consist of at least 20 percent feldspar. Garnet is frequently present; some hornblende or biotite may be present. The rock has a granoblastic texture and gneissose to massive structure; grain size and fabric may be variable on a decimetric scale. Foliation is less well developed than in rock that would typically be called gneiss. The minerals present in a granulite vary depending on the protolith and the temperature and pressure conditions experienced during metamorphism. According to Fettes and Desmons (2007) the main calc-silicate minerals are calcic garnet, calcic plagioclase, calcic scapolite, diopside-hedenbergite, epidote group minerals, hydrogrossular, johannsenite, prehnite, pumpellyite, titanite, vesuvianite, wollastonite. Note that the shale and siltstone categories may apply to any of the mineralogically defined mudstone categories."@en ;
-  rdfs:label "granulite"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Gravel
-  rdf:type owl:Class ;
-  dct:source "definition of gravel from SLTTs 2004; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
-  rdfs:comment "Clastic sediment containing greater than 30 percent gravel-size particles (greater than 2.0 mm diameter). Gravel in which more than half of the particles are of epiclastic origin"@en ;
-  rdfs:label "gravel"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sediment ;
-  rdfs:subClassOf gsrm:Gravel_Size_Sediment ;
-.
-gsrm:Gravel_Size_Sediment
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
-  rdfs:comment "Sediment containing greater than 30 percent gravel-size particles (greater than 2.0 mm diameter). Composition or gensis of clasts not specified."@en ;
-  rdfs:label "gravel size sediment"@en ;
-  rdfs:subClassOf gsrm:Sediment ;
-.
-gsrm:High_Magnesium_Fine_Grained_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "fine-grained igneous rock that contains unusually high concentration of MgO. For rocks that contain greater than 52 percent silica, MgO must be greater than 8 percent. For rocks containing less than 52 percent silica, MgO must be greater than 12 percent."@en ;
-  rdfs:label "high magnesium fine grained igneous rock"@en ;
-  rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
-.
-gsrm:Hornblendite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Ultramafic rock that consists of greater than 40 percent hornblende plus pyroxene and has a hornblende to pyroxene ratio greater than 1. Includes olivine hornblendite, olivine-pyroxene hornblendite, pyroxene hornblendite, and hornblendite."@en ;
-  rdfs:label "hornblendite"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Ultramafic_Igneous_Rock ;
-.
-gsrm:Hornfels
-  rdf:type owl:Class ;
-  dct:source "IUGS SCMR 2007 (http://www.bgs.ac.uk/SCMR/)"@en ;
-  rdfs:comment "Granofels formed by contact metamorphism, composed of a mosaic of equidimensional grains in a characteristically granoblastic or decussate matrix; porphyroblasts or relict phenocrysts may be present. Typically fine grained."@en ;
-  rdfs:label "hornfels"@en ;
-  rdfs:subClassOf gsrm:Granofels ;
-.
-gsrm:Hybrid_Sediment
-  rdf:type owl:Class ;
-  dct:source "Hallsworth and Knox, 1999"@en ;
-  rdfs:comment "Sediment that does not fit any of the other sediment composition/genesis categories. Sediment consisting of three or more components which form more than 5 percent but less than 50 precent of the material."@en ;
-  rdfs:label "hybrid sediment"@en ;
-  rdfs:subClassOf gsrm:Sediment ;
-.
-gsrm:Hybrid_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "Hallsworth and Knox, 1999"@en ;
-  rdfs:comment "Sedimentary rock that does not fit any of the other composition/genesis categories. Sedimentary rock consisting of three or more components which form more than 5 percent but less than 50 precent of the material."@en ;
-  rdfs:label "hybrid sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Sedimentary_Rock ;
-.
-gsrm:Hydrothermal_Massive_Sulphide
-  rdf:type owl:Class ;
-  dct:source "provisional by SMR 2020-06-07"@en ;
-  rdfs:comment "Rock consisting of greater that 50% sulphide or sulfosalt minerals formed by hydrothermal mineralization processes {@en}." ;
-  rdfs:label "Hydrothermal Massive Sulphide"@en ;
-  rdfs:subClassOf gsrm:Massive_Sulphide ;
-  rdfs:subClassOf gsrm:Metasomatic_Rock ;
-  skos:altLabel "Hydrothermal Massive Sulfide"@en ;
-.
-gsrm:Hypabyssal_Intrusive_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Igneous rocks formed by crystallisation close to the Earth's surface, characterized by more rapid cooling than plutonic setting to produce generally fine-grained intrusive igneous rock, commonly associated with co-magmatic volcanic rocks."@en ;
-  rdfs:label "hypabyssal intrusive rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Igneous_Material
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Earth material formed as a result of igneous processes, eg. intrusion and cooling of magma in the crust, volcanic eruption."@en ;
-  rdfs:label "igneous material"@en ;
-  rdfs:subClassOf gsog:Rock_Material ;
-.
-gsrm:Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al 2005"@en ;
-  rdfs:comment "rock formed as a result of igneous processes, for example intrusion and cooling of magma in the crust, or volcanic eruption."@en ;
-  rdfs:label "igneous rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Material ;
-  rdfs:subClassOf gsrm:Rock ;
-.
-gsrm:Impure_Calcareous_Carbonate_Sediment
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Carbonate sediment in which between 50 and 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin, and a calcite (plus aragonite) to dolomite ratio greater than 1 to 1."@en ;
-  rdfs:label "impure calcareous carbonate sediment"@en ;
-  rdfs:subClassOf gsrm:Calcareous_Carbonate_Sediment ;
-  rdfs:subClassOf gsrm:Impure_Carbonate_Sediment ;
-  skos:altLabel "calcareous marl"@en ;
-.
-gsrm:Impure_Carbonate_Sediment
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Carbonate sediment in which between 50 and 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin."@en ;
-  rdfs:label "impure carbonate sediment"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sediment ;
-  skos:altLabel "marl"@en ;
-.
-gsrm:Impure_Carbonate_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Sedimentary rock in which between 50 and 90 percent of the primary and/or recrystallized constituents are composed of carbonate minerals."@en ;
-  rdfs:label "impure carbonate sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-  skos:altLabel "marlstone"@en ;
-.
-gsrm:Impure_Dolomitic_Sediment
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Carbonate sediment in which between 50 and 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin, and the ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1."@en ;
-  rdfs:label "impure dolomitic sediment"@en ;
-  rdfs:subClassOf gsrm:Dolomitic_Sediment ;
-  rdfs:subClassOf gsrm:Impure_Carbonate_Sediment ;
-  skos:altLabel "dolomitic marl"@en ;
-.
-gsrm:Impure_Dolostone
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Impure carbonate sedimentary rock with a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1."@en ;
-  rdfs:label "impure dolomite"@en ;
-  rdfs:subClassOf gsrm:Dolomitic_Or_Magnesian_Sedimentary_Rock ;
-  rdfs:subClassOf gsrm:Impure_Carbonate_Sedimentary_Rock ;
-  skos:altLabel "dolomitic marlstone"@en ;
-  skos:altLabel "impure dolomitic or magnesian carbonate sedimentary rock"@en ;
-  skos:altLabel "impure dolostone"@en ;
-.
-gsrm:Impure_Limestone
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Impure carbonate sedimentary rock with a calcite (plus aragonite) to dolomite ratio greater than 1 to 1."@en ;
-  rdfs:label "impure limestone"@en ;
-  rdfs:subClassOf gsrm:Calcareous_Carbonate_Sedimentary_Rock ;
-  rdfs:subClassOf gsrm:Impure_Carbonate_Sedimentary_Rock ;
-  skos:altLabel "calcareous marlstone"@en ;
-.
-gsrm:Intermediate_Composition_Igneous_Material
-  rdf:type owl:Class ;
-  dct:source "after LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous material with between 52 and 63 percent SiO2."@en ;
-  rdfs:label "intermediate composition igneous material"@en ;
-  rdfs:subClassOf gsrm:Igneous_Material ;
-.
-gsrm:Intermediate_Composition_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "after LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous rock with between 52 and 63 percent SiO2."@en ;
-  rdfs:label "intermediate composition igneous rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-  rdfs:subClassOf gsrm:Intermediate_Composition_Igneous_Material ;
-.
-gsrm:Iron_Rich_Sediment
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sediment that consists of at least 50 percent iron-bearing minerals (hematite, magnetite, limonite-group, siderite, iron-sulfides), as determined by hand-lens or petrographic analysis. Corresponds to a rock typically containing 15 percent iron by weight."@en ;
-  rdfs:label "iron rich sediment"@en ;
-  rdfs:subClassOf gsrm:Iron_Rich_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sediment ;
-.
-gsrm:Iron_Rich_Sedimentary_Material
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sedimentary material of unspecified consolidation state that consists of at least 50 percent iron-bearing minerals (hematite, magnetite, limonite-group, siderite, iron-sulfides), as determined by hand-lens or petrographic analysis. Corresponds to a rock typically containing 15 percent iron by weight."@en ;
-  rdfs:label "iron rich sedimentary material"@en ;
-  rdfs:subClassOf gsrm:Chemical_Sedimentary_Material ;
-.
-gsrm:Iron_Rich_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "Hallsworth and Knox 1999; SLTTs 2004"@en ;
-  rdfs:comment "Sedimentary rock that consists of at least 50 percent iron-bearing minerals (hematite, magnetite, limonite-group, siderite, iron-sulfides), as determined by hand-lens or petrographic analysis. Corresponds to a rock typically containing 15 percent iron by weight."@en ;
-  rdfs:label "iron rich sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Iron_Rich_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sedimentary_Rock ;
-.
-gsrm:Kalsilitic_And_Melilitic_Rock
-  rdf:type owl:Class ;
-  dct:source "based on LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous rock containing greater than 10 percent melilite or kalsilite. Typically undersaturated, ultrapotassic (kalsilitic rocks) or calcium-rich (melilitic rocks) mafic or ultramafic rocks."@en ;
-  rdfs:label "kalsilitic and melilitic rocks"@en ;
-  rdfs:subClassOf gsrm:Exotic_Composition_Igneous_Rock ;
-.
-gsrm:Komatiitic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Ultramafic, magnesium-rich volcanic rock, typically with spinifex texture of intergrown skeletal and bladed olivine and pyroxene crystals set in abundant glass. Includes komatiite and meimechite."@en ;
-  rdfs:label "komatiitic rock"@en ;
-  rdfs:subClassOf gsrm:High_Magnesium_Fine_Grained_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Ultramafic_Igneous_Rock ;
-.
-gsrm:Latite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Latitic rock that contains between 0 and 5 percent quartz and no feldspathoid in the QAPF fraction. QAPF field 8."@en ;
-  rdfs:label "latite"@en ;
-  rdfs:subClassOf gsrm:Latitic_Rock ;
-.
-gsrm:Latitic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Trachytoid that has a plagioclase to total feldspar ratio between 0.35 and 0.65. QAPF fields 8, 8' and 8*."@en ;
-  rdfs:label "latitic rock"@en ;
-  rdfs:subClassOf gsrm:Trachytoid ;
-.
-gsrm:Lignite
-  rdf:type owl:Class ;
-  dct:source "Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp."@en ;
-  rdfs:comment "Coal that has a gross calorific value less than 24 MJ/kg (determined in conformance with ISO 1928), and vitrinite mean random reflectance less than 0.6% (determined in conformance with ISO 7404-5). Gross calorific value is recalculated to a moist, ash free basis using bed moisture (determined according to ISO 1015 or ISO 5068). Includes all low-rank coals, including sub-bitiminous coal. A consolidated, dull, soft brown to black coal having many readily discernible plant fragments set in a finer grained organic matrix. Tends to crack and fall apart on drying. Operationally sub-bituminous and bitiminous coal are qualitatively distinguished based on brown streak for sub-bitiminous coal and black streak for bituminous coal."@en ;
-  rdfs:label "lignite"@en ;
-  rdfs:subClassOf gsrm:Coal ;
-  skos:altLabel "low rank coal"@en ;
-.
-gsrm:Limestone
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Pure carbonate sedimentary rock with a calcite (plus aragonite) to dolomite ratio greater than 1 to 1. Includes limestone and dolomitic limestone."@en ;
-  rdfs:label "limestone"@en ;
-  rdfs:subClassOf gsrm:Calcareous_Carbonate_Sedimentary_Rock ;
-  rdfs:subClassOf gsrm:Pure_Carbonate_Sedimentary_Rock ;
-.
-gsrm:Marble
-  rdf:type owl:Class ;
-  dct:source "IUGS SCMR 2007 (http://www.bgs.ac.uk/SCMR/), SLTTm1.0 2004"@en ;
-  rdfs:comment "Metamorphic rock consisting of greater than 75 percent fine- to coarse-grained recrystallized calcite and/or dolomite; usually with a granoblastic, saccharoidal texture."@en ;
-  rdfs:label "marble"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Massive_Sulphide
-  rdf:type owl:Class ;
-  dct:source "Provisional SMR 2020-06-07"@en ;
-  rdfs:comment "rock consisting of greater than 50% sulphide or sulfosalt minerals formed by any processes. Includes hydrothermal and sedimentary ehalative sulfide."@en ;
-  rdfs:label "Massive sulphide"@en ;
-  rdfs:subClassOf gsrm:Rock ;
-  skos:altLabel "Massive Sulfide"@en ;
-.
-gsrm:Metamorphic_Rock
-  rdf:type owl:Class ;
-  dct:source "Jackson 1997"@en ;
-  rdfs:comment "Robertson (1999, Classification of metamorphic rocks: British Geological Survey Research Report, RR 99–02) defines the boundary between diagenesis and metamorphism in sedimentary rocks as follows: “…the boundary between diagenesis and metamorphism is somewhat arbitrary and strongly dependent on the lithologies involved. For example changes take place in organic materials at lower temperatures than in rocks dominated by silicate minerals. In mudrocks, a white mica (illite) crystallinity value of less than 0.42 Delta 2 Theta obtained by X-ray diffraction analysis, is used to define the onset of metamorphism (Kisch, 1991). In this scheme, the first appearance of glaucophane, lawsonite, paragonite, prehnite, pumpellyite or stilpnomelane is taken to indicate the lower limit of metamorphism (Frey and Kisch, 1987; Bucher and Frey, 1994; Frey and Robinson, 1998). Most workers agree that such mineral growth starts at 150 +/- 50° C in silicate rocks. Many lithologies may show no change in mineralogy under these conditions and hence the recognition of the onset of metamorphism will vary with bulk composition.”"@en ;
-  rdfs:comment "Rock formed by solid-state mineralogical, chemical and/or structural changes to a pre-existing rock, in response to marked changes in temperature, pressure, shearing stress and chemical environment."@en ;
-  rdfs:label "metamorphic rock"@en ;
-  rdfs:subClassOf gsrm:Composite_Genesis_Rock ;
-.
-gsrm:Metaplutonic_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Rock formed by metamorphism of a plutonic igneous protolith."@en ;
-  rdfs:label "metaplutonic rock"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Metasedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Rock formed by metamorphism of a sedimentary protolith."@en ;
-  rdfs:label "metasedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Metasomatic_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Rock that has fabric and composition indicating open-system mineralogical and chemical changes in response to interaction with a fluid phase, typically water rich."@en ;
-  rdfs:comment "SLTTm (2004) proposed the following criteria to distinguish hydrothermally altered or metasomatic rock from igneous rock. \"The rock is classified as metamorphic if (1) the texture has been modified such that it can no longer be considered igneous, (2) the bulk composition of the rock is inconsistent with compositions that can be derived purely from a magma and associated processes such as assimilation and differentiation, or (3) minerals inconsistent with magmatic crystallization are present.\""@en ;
-  rdfs:label "metasomatic rock"@en ;
-  rdfs:subClassOf gsrm:Composite_Genesis_Rock ;
-.
-gsrm:Metavolcanic_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Rock formed by metamorphism of an extrusive igneous protolith."@en ;
-  rdfs:label "metavolcanic rock"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Mica_Schist
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "A schist that consists of more than 50 percent mica minerals, typically muscovite or biotite. Special type included to distinguish this common variety of schist."@en ;
-  rdfs:comment "Include single subcategory of schist to indicate this common kind of schist. 'Mica rich metamorphic rock' for compound use with schist fabric term would be more compatible with treatment of blueschist (Glaucophane lawsonite epidote metamorphic rock) and greenschist (Chlorite actinolite epidote metamorphic rock), but based on the assumption that schist is the only rock type that will meet the mica-rich criteria, it seems reasonable to include as a subtype of schist."@en ;
-  rdfs:label "mica schist"@en ;
-  rdfs:subClassOf gsrm:Schist ;
-.
-gsrm:Migmatite
-  rdf:type owl:Class ;
-  dct:source "Fette and Desmons (2007) (http://www.bgs.ac.uk/SCMR/)"@en ;
-  rdfs:comment "Silicate metamorphic rock that is pervasively heterogeneous on a decimeter to meter scale that typically consists of darker and lighter parts; the darker parts usually exhibit features of metamorphic rocks whereas the lighter parts are of igneous-looking appearance."@en ;
-  rdfs:label "migmatite"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Monzodiorite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline igneous rock consisting of sodic plagioclase (An0 to An50), alkali feldspar, hornblende and biotite, with or without pyroxene, and 0 to 5 percent quartz. Includes rocks defined modally in QAPF field 9."@en ;
-  rdfs:label "monzodiorite"@en ;
-  rdfs:subClassOf gsrm:Monzodioritic_Rock ;
-.
-gsrm:Monzodioritic_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary; LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline igneous rock consisting of sodic plagioclase (An0 to An50), alkali feldspar, hornblende and biotite, with or without pyroxene, and 0 to 10 percent feldspathoid or 0 to 20 percent quartz in the QAPF fraction. Plagioclase to total feldspar ratio in the QAPF fraction is between 0.65 and 0.9. Includes rocks defined modally in QAPF field 9, 9' and 9* as monzodiorite, foid-beaing monzodiorite, and quartz monzodiorite."@en ;
-  rdfs:label "monzodioritic rock"@en ;
-  rdfs:subClassOf gsrm:Dioritoid ;
-.
-gsrm:Monzogabbro
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002, This vocabulary"@en ;
-  rdfs:comment "Monzogabbroic rock that contains between 0 an 5 percent quartz and no feldspathoid mineral in the QAPF fraction. Includes rocks defined modally in QAPF field 9 ."@en ;
-  rdfs:label "monzogabbro"@en ;
-  rdfs:subClassOf gsrm:Monzogabbroic_Rock ;
-.
-gsrm:Monzogabbroic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002, This vocabulary"@en ;
-  rdfs:comment "Gabbroid with a plagioclase to total feldspar ratio between 0.65 and 0.9. QAPF field 9, 9 prime and 9 asterisk"@en ;
-  rdfs:label "monzogabbroic rock"@en ;
-  rdfs:subClassOf gsrm:Gabbroid ;
-.
-gsrm:Monzogranite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Granite that has a plagiolcase to total feldspar ratio between 0.35 and 0.65. QAPF field 3b."@en ;
-  rdfs:label "monzogranite"@en ;
-  rdfs:subClassOf gsrm:Granite ;
-.
-gsrm:Monzonite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Monzonitic rock that contains 0-5 percent quartz and no feldspathoid mineral in the QAPF fraction. Includes rocks defined modally in QAPF Field 8."@en ;
-  rdfs:label "monzonite"@en ;
-  rdfs:subClassOf gsrm:Monzonitic_Rock ;
-.
-gsrm:Monzonitic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Syenitoid with a plagioclase to total feldspar ratio between 0.35 and 0.65. Includes rocks in QAPF fields 8, 8*, and 8'."@en ;
-  rdfs:label "monzonitic rock"@en ;
-  rdfs:subClassOf gsrm:Syenitoid ;
-.
-gsrm:Mud
-  rdf:type owl:Class ;
-  dct:source "definition of mud from SLTTs 2004 muddy sediment; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
-  rdfs:comment "Clastic sediment consisting of less than 30 percent gravel-size (2 mm) particles and with a mud-size to sand-size particle ratio greater than 1. More than half of the particles are of epiclastic origin."@en ;
-  rdfs:label "mud"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sediment ;
-  rdfs:subClassOf gsrm:Mud_Size_Sediment ;
-.
-gsrm:Mud_Size_Sediment
-  rdf:type owl:Class ;
-  dct:source "based on SLTTs 2004; Neuendorf et al. 2005; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
-  rdfs:comment "Sediment consisting of less than 30 percent gravel-size (2 mm) particles and with a mud-size to sand-size particle ratio greater than 1. Clasts may be of any composition or origin.  BGS  (Hallsworth and Knox, 1999, p. 9) define the  'upper size limit of mud ... at 32 micrometers (.032 mm)', but Wentworth scale and Krumbein scale put boundary at .064 or .062 mm (inidistinguishable difference in rocks...) BGS 'mud-grade sediment' or sedimentary rock definition is 'over 75% of the clasts smaller than  .032 mm', which is narrower than the definition here."@en ;
-  rdfs:label "mud size sediment"@en ;
-  rdfs:subClassOf gsrm:Sediment ;
-.
-gsrm:Mylonitic_Rock
-  rdf:type owl:Class ;
-  dct:source "Marshak and Mitra 1988"@en ;
-  rdfs:comment "Metamorphic rock characterised by a foliation resulting from tectonic grain size reduction, in which more than 10 percent of the rock volume has undergone grain size reduction. Includes protomylonite, mylonite, ultramylonite, and blastomylonite."@en ;
-  rdfs:label "mylonitic rock"@en ;
-  rdfs:subClassOf gsrm:Foliated_Metamorphic_Rock ;
-  rdfs:subClassOf gsrm:fault_related_material ;
-.
-gsrm:Natural_Unconsolidated_Material
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Unconsolidated material known to have natural, ie. not human-made, origin."@en ;
-  rdfs:label "natural unconsolidated material"@en ;
-  rdfs:subClassOf gsrm:Unconsolidated_Material ;
-.
-gsrm:Non_Clastic_Siliceous_Sediment
-  rdf:type owl:Class ;
-  dct:source "NGMDB 2008; Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Sediment that consists of at least 50 percent silicate mineral material, deposited directly by chemical or biological processes at the depositional surface, or in particles formed by chemical or biological processes within the basin of deposition."@en ;
-  rdfs:label "non clastic siliceous sediment"@en ;
-  rdfs:subClassOf gsrm:Non_Clastic_Siliceous_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sediment ;
-.
-gsrm:Non_Clastic_Siliceous_Sedimentary_Material
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sedimentary material that consists of at least 50 percent silicate mineral material, deposited directly by chemical or biological processes at the depositional surface, or in particles formed by chemical or biological processes within the basin of deposition."@en ;
-  rdfs:label "non clastic siliceous sedimentary material"@en ;
-  rdfs:subClassOf gsrm:Sedimentary_Material ;
-.
-gsrm:Non_Clastic_Siliceous_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "modified from SLTTs 2004"@en ;
-  rdfs:comment "Definition updated to include chert, flint SMR 2020-09-21"@en ;
-  rdfs:comment "Sedimentary rock that consists of at least 50 percent silicate mineral material, deposited directly by chemical or biological processes at the depositional surface, in particles formed by chemical or biological processes within the basin of deposition, or formed by diagenetic processes. Includes chert and flint found in carbonate rocks."@en ;
-  rdfs:label "non clastic siliceous sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Non_Clastic_Siliceous_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sedimentary_Rock ;
-.
-gsrm:Ooze
-  rdf:type owl:Class ;
-  dct:source "based on Bates and Jackson 1987 and Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Biogenic sediment consisting of less than 1 percent gravel-size (greater than or equal to 2 mm) particles, with a sand to mud ratio less than 1 to 9, and less than 50 percent carbonate minerals."@en ;
-  rdfs:comment "Neuendorf et al. 2005 put cutoff at 30 percent skeletal remains; this is raised to 50 percent in This vocabulary for consistency with definition of other Biogenic sediment category"@en ;
-  rdfs:label "ooze"@en ;
-  rdfs:subClassOf gsrm:Biogenic_Sediment ;
-  rdfs:subClassOf gsrm:Mud_Size_Sediment ;
-  skos:altLabel "biogenic mud"@en ;
-.
-gsrm:Organic_Bearing_Mudstone
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005; http://en.wikipedia.org/wiki/Oil_shale"@en ;
-  rdfs:comment "Mudstone that contains a significant amount of organic carbon, typically kerogen. commonly finely laminated, brown or black in color."@en ;
-  rdfs:label "organic bearing mudstone"@en ;
-  rdfs:subClassOf gsrm:Generic_Mudstone ;
-  skos:altLabel "oil shale"@en ;
-.
-gsrm:Organic_Rich_Sediment
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sediment with color, composition, texture and apparent density indicating greater than 50 percent organic content by weight on a moisture-free basis."@en ;
-  rdfs:comment "The broader relation from organic rich sediment to biogenic sediment is based on the inference that organic rich material is always biogenic in origin. Biogenic is a broader category because not all biogenic materials are organic rich, for example shells or phosphatic bone."@en ;
-  rdfs:label "organic rich sediment"@en ;
-  rdfs:subClassOf gsrm:Biogenic_Sediment ;
-  rdfs:subClassOf gsrm:Organic_Rich_Sedimentary_Material ;
-.
-gsrm:Organic_Rich_Sedimentary_Material
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sedimentary material in which 50 percent or more of the primary sedimentary material is organic carbon."@en ;
-  rdfs:label "organic rich sedimentary material"@en ;
-  rdfs:subClassOf gsrm:Sedimentary_Material ;
-.
-gsrm:Organic_Rich_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sapropelic coal, and asphaltite are not differentiated in This vocabulary"@en ;
-  rdfs:comment "Sedimentary rock with color, composition, texture and apparent density indicating greater than 50 percent organic content by weight on a moisture-free basis."@en ;
-  rdfs:label "organic rich sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Organic_Rich_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sedimentary_Rock ;
-.
-gsrm:Orthogneiss
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "A gneiss with mineralogy and texture indicating derivation from a phaneritic igneous rock protolith. Typically consists of abundant feldspar, with quartz, and variable hornblende, biotite, and muscovite, with a relatively homogeneous character."@en ;
-  rdfs:label "orthogneiss"@en ;
-  rdfs:subClassOf gsrm:Gneiss ;
-.
-gsrm:Packstone
-  rdf:type owl:Class ;
-  dct:source "Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Carbonate sedimentary rock with discernible grain supported depositional texture, containing greater than 10 percent grains, and constituent particles are of intrabasinal origin; intergranular spaces are filled by matrix."@en ;
-  rdfs:comment "Note that this category overlaps with 'carbonate mudstone'."@en ;
-  rdfs:label "packstone"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-.
-gsrm:Paragneiss
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "A gneiss with mineralogy and texture indicating derivation from a sedimentary rock protolith. Typically consists of abundant quartz, mica, or calcsilicate minerals; aluminosilicate minerals or garnet commonly present. composition of rock tends to be more variable on a decimetric scale that in orthogneiss."@en ;
-  rdfs:label "paragneiss"@en ;
-  rdfs:subClassOf gsrm:Gneiss ;
-.
-gsrm:Peat
-  rdf:type owl:Class ;
-  dct:source "Hallsworth and Knox 1999"@en ;
-  rdfs:comment "Unconsolidated organic-rich sediment composed of at least 50 percent semi-carbonised plant remains; individual remains commonly seen with unaided eye; yellowish brown to brownish black; generally fibrous texture; can be plastic or friable. In its natural state it can be readily cut and has a very high moisture content, generally greater than 90 percent. Liptinite to Inertinite ratio is less than one (Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp.)"@en ;
-  rdfs:label "peat"@en ;
-  rdfs:subClassOf gsrm:Organic_Rich_Sediment ;
-.
-gsrm:Pebble_Gravel_Size_Sediment
-  rdf:type owl:Class ;
-  dct:source "Wentworth size scale"@en ;
-  rdfs:comment "Sediment containing greater than 30 percent pebble-size particles (2.0 -64 mm in diameter)"@en ;
-  rdfs:label "pebble gravel size sediment"@en ;
-  rdfs:subClassOf gsrm:Gravel_Size_Sediment ;
-.
-gsrm:Pegmatite
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005"@en ;
-  rdfs:comment "Exceptionally coarse grained crystalline rock with interlocking crystals; most grains are 1cm or more diameter; composition is generally that of granite, but the term may refer to the coarse grained facies of any type of igneous rock;usually found as irregular dikes, lenses, or veins associated with plutons or batholiths."@en ;
-  rdfs:label "pegmatite"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Peridotite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Ultramafic rock consisting of more than 40 percent (by volume) olivine with pyroxene and/or amphibole and little or no feldspar. commonly altered to serpentinite. Includes rocks defined modally in the ultramafic rock classification as dunite, harzburgite, lherzolite, wehrlite, olivinite, pyroxene peridotite, pyroxene hornblende peridotite or hornblende peridotite."@en ;
-  rdfs:label "peridotite"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Ultramafic_Igneous_Rock ;
-.
-gsrm:Phaneritic_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005"@en ;
-  rdfs:comment "Igneous rock in which the framework of the rock consists of individual crystals that can be discerned with the unaided eye. Bounding grain size is on the order of 32 to 100 microns. Igneous rocks with 'exotic' composition are excluded from this concept."@en ;
-  rdfs:label "phaneritic igneous rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-  skos:altLabel "coarse grained crystalline igneous rock"@en ;
-  skos:altLabel "plutonic rock"@en ;
-.
-gsrm:Phonolilte
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phonolitoid in which the plagioclase to total feldspar ratio is less than 0.1. Rock consists of alkali feldspar, feldspathoid minerals, and mafic minerals."@en ;
-  rdfs:label "phonolite"@en ;
-  rdfs:subClassOf gsrm:Phonolitoid ;
-.
-gsrm:Phonolitic_Basanite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Tephritoid that has a plagioclase to total feldspar ratio between 0.5 and 0.9, and contains more than 10 percent normative (CIPW) olivine."@en ;
-  rdfs:label "phonolitic basanite"@en ;
-  rdfs:subClassOf gsrm:Tephritoid ;
-.
-gsrm:Phonolitic_Foidite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Foiditoid that contains less than 90 percent feldspathoid minerals in the QAPF fraction, and has a plagioclase to total feldspar ratio that is less than 0.5"@en ;
-  rdfs:label "phonolitic foidite"@en ;
-  rdfs:subClassOf gsrm:Foiditoid ;
-.
-gsrm:Phonolitic_Tephrite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Tephritoid that has a plagioclase to total feldspar ratio between 0.5 and 0.9, and contains less than 10 percent normative (CIPW) olivine."@en ;
-  rdfs:label "phonolitic tephrite"@en ;
-  rdfs:subClassOf gsrm:Tephritoid ;
-.
-gsrm:Phonolitoid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Fine grained igneous rock than contains less than 90 percent mafic minerals, between 10 and 60 percent feldspathoid mineral in the QAPF fraction and has a plagioclase to total feldspar ratio less than 0.5. Includes rocks defined modally in QAPF fields 11 and 12, and TAS field Ph."@en ;
-  rdfs:label "phonolitoid"@en ;
-  rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
-  skos:altLabel "phonolitic rock"@en ;
-.
-gsrm:Phosphate_Rich_Sediment
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sediment in which at least 50 percent of the primary and/or recrystallized constituents are phosphate minerals."@en ;
-  rdfs:label "phosphate rich sediment"@en ;
-  rdfs:subClassOf gsrm:Phosphate_Rich_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sediment ;
-.
-gsrm:Phosphate_Rich_Sedimentary_Material
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Sedimentary material in which at least 50 percent of the primary and/or recrystallized constituents are phosphate minerals."@en ;
-  rdfs:label "phosphate rich sedimentary material"@en ;
-  rdfs:subClassOf gsrm:Sedimentary_Material ;
-.
-gsrm:Phosphorite
-  rdf:type owl:Class ;
-  dct:source "HallsworthandKnox 1999, Jackson 1997"@en ;
-  rdfs:comment "Sedimentary rock in which at least 50 percent of the primary or recrystallized constituents are phosphate minerals. Most commonly occurs as a bedded primary or reworked secondary marine rock, composed of microcrystalline carbonate fluorapatite in the form of lamina, pellets, oolites and nodules, and skeletal, shell and bone fragments."@en ;
-  rdfs:label "phosphorite"@en ;
-  rdfs:subClassOf gsrm:Phosphate_Rich_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Sedimentary_Rock ;
-.
-gsrm:Phyllite
-  rdf:type owl:Class ;
-  dct:source "IUGS SCMR 2007 (http://www.bgs.ac.uk/SCMR/)"@en ;
-  rdfs:comment "Rock with a well developed, continuous schistosity, an average grain size between 0.1 and 0.5 millimeters, and a silvery sheen on cleavage surfaces. Individual phyllosilicate grains are barely visible with the unaided eye."@en ;
-  rdfs:label "phyllite"@en ;
-  rdfs:subClassOf gsrm:Foliated_Metamorphic_Rock ;
-.
-gsrm:Phyllonite
-  rdf:type owl:Class ;
-  dct:source "NADM metamorphic rock vocabulary SLTTm1.0; Marshak and Mitra 1988"@en ;
-  rdfs:comment "Mylonitic rock composed largely of fine-grained mica that imparts a sheen to foliation surfaces; may have flaser lamination, isoclinal folding, and deformed veins, which indicate significant shearing. Macroscopically resembles phyllite, but formed by mechanical degradation of initially coarser rock."@en ;
-  rdfs:label "phyllonite"@en ;
-  rdfs:subClassOf gsrm:Mylonitic_Rock ;
-.
-gsrm:Plutonic_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Instrusive igneous rock formed by crystallisation of magma far enough below Earth surface that complete crystallization of magma bodies forms holocrystalline medium to coarse grained igneous rock, wall rocks generally do not include volcanic products related to the magma, and some contact metamorphism is tyypically developed at intrusive contacts."@en ;
-  rdfs:label "plutonic rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Porphyry
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous rock that contains conspicuous phenocrysts in a finer grained groundmass; groundmass itself may be phaneritic or fine-grained."@en ;
-  rdfs:label "porphyry"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Pure_Calcareous_Carbonate_Sediment
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Carbonate sediment in which greater than 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin, and a calcite (plus aragonite) to dolomite ratio greater than 1 to 1."@en ;
-  rdfs:label "pure calcareous carbonate sediment"@en ;
-  rdfs:subClassOf gsrm:Calcareous_Carbonate_Sediment ;
-  rdfs:subClassOf gsrm:Pure_Carbonate_Sediment ;
-  skos:altLabel "lime sediment"@en ;
-.
-gsrm:Pure_Carbonate_Mudstone
-  rdf:type owl:Class ;
-  dct:source "Dunham 1962"@en ;
-  rdfs:comment "Mudstone that consists of greater than 90 percent carbonate minerals of intrabasinal orign in the mud fraction, and contains less than 10 percent allochems. The original depositional texture is preserved and fabric is matrix supported. Carbonate mudstone of Dunham (1962)"@en ;
-  rdfs:label "pure carbonate mudstone"@en ;
-  rdfs:subClassOf gsrm:Generic_Mudstone ;
-  rdfs:subClassOf gsrm:Pure_Carbonate_Sedimentary_Rock ;
-.
-gsrm:Pure_Carbonate_Sediment
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Carbonate sediment in which greater than 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin."@en ;
-  rdfs:label "pure carbonate sediment"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sediment ;
-.
-gsrm:Pure_Carbonate_Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Sedimentary rock in which greater than 90 percent of the primary and/or recrystallized constituents are carbonate minerals."@en ;
-  rdfs:label "pure carbonate sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
-.
-gsrm:Pure_Dolomitic_Sediment
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Carbonate sediment in which greater than 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin, and a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1."@en ;
-  rdfs:label "pure dolomitic sediment"@en ;
-  rdfs:subClassOf gsrm:Dolomitic_Sediment ;
-  rdfs:subClassOf gsrm:Pure_Carbonate_Sediment ;
-.
-gsrm:Pyroclastic_Material
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Fragmental igneous material that consists of more than 75 percent of particles formed by disruption as a direct result of volcanic action."@en ;
-  rdfs:label "pyroclastic material"@en ;
-  rdfs:subClassOf gsrm:Fragmental_Igneous_Material ;
-.
-gsrm:Pyroclastic_Rock
-  rdf:type owl:Class ;
-  dct:source "based on LeMaitre et al. 2002"@en ;
-  rdfs:comment "Fragmental igneous rock that consists of greater than 75 percent fragments produced as a direct result of eruption or extrusion of magma from within the earth onto its surface. Includes autobreccia associated with lava flows and excludes deposits reworked by epiclastic processes."@en ;
-  rdfs:label "pyroclastic rock"@en ;
-  rdfs:subClassOf gsrm:Fragmental_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Pyroclastic_Material ;
-.
-gsrm:Pyroxenite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Ultramafic phaneritic igneous rock composed almost entirely of one or more pyroxenes and occasionally biotite, hornblende and olivine. Includes rocks defined modally in the ultramafic rock classification as olivine pyroxenite, olivine-hornblende pyroxenite, pyroxenite, orthopyroxenite, clinopyroxenite and websterite."@en ;
-  rdfs:label "pyroxenite"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Ultramafic_Igneous_Rock ;
-.
-gsrm:Quartz_Alkali_Feldspar_Syenite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Alkali feldspar syenitic rock that contains 5 to 20 percent quartz and no feldspathoid in the QAPF fraction. QAPF field 6*."@en ;
-  rdfs:label "quartz alkali feldspar syenite"@en ;
-  rdfs:subClassOf gsrm:Alkali_Feldspar_Syenitic_Rock ;
-.
-gsrm:Quartz_Alkali_Feldspar_Trachyte
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Alkali feldspar trachytic rock that contains and between 5 and 20 percent quartz mineral in the QAPF fraction. QAPF field 6*."@en ;
-  rdfs:label "quartz alkali feldspar trachyte"@en ;
-  rdfs:subClassOf gsrm:Alkali_Feldspar_Trachytic_Rock ;
-.
-gsrm:Quartz_Anorthosite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Anorthositic rock that contains between 5 and 20 percent quartz in the QAPF fraction. QAPF field 10*."@en ;
-  rdfs:label "quartz anorthosite"@en ;
-  rdfs:subClassOf gsrm:Anorthositic_Rock ;
-.
-gsrm:Quartz_Diorite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Dioritic rock that contains between 5 to 20 percent quartz in the QAPF fraction. QAPF field 10*."@en ;
-  rdfs:label "quartz diorite"@en ;
-  rdfs:subClassOf gsrm:Dioritic_Rock ;
-.
-gsrm:Quartz_Gabbro
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Gabbroic rock that contains between 5 and 20 percent quartz in the QAPF fraction. QAPF field 10*."@en ;
-  rdfs:label "quartz gabbro"@en ;
-  rdfs:subClassOf gsrm:Gabbroic_Rock ;
-.
-gsrm:Quartz_Latite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Latitic rock that contains between 5 and 20 percent quartz in the QAPF fraction. QAPF field 8*."@en ;
-  rdfs:label "quartz latite"@en ;
-  rdfs:subClassOf gsrm:Latitic_Rock ;
-.
-gsrm:Quartz_Monzodiorite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Monzodioritic rock that contains between 5 and 20 percent quartz."@en ;
-  rdfs:label "quartz monzodiorite"@en ;
-  rdfs:subClassOf gsrm:Monzodioritic_Rock ;
-.
-gsrm:Quartz_Monzogabbro
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Monzogabbroic rock that contains between 5 and 20 percent quartz in the QAPF fraction. QAPF field 9*."@en ;
-  rdfs:label "quartz monzogabbro"@en ;
-  rdfs:subClassOf gsrm:Monzogabbroic_Rock ;
-.
-gsrm:Quartz_Monzonite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Monzonitic rock that contains 5-20 percent quartz iin the QAPF fraction. Includes rocks defined modally in QAPF Field 8*."@en ;
-  rdfs:label "quartz monzonite"@en ;
-  rdfs:subClassOf gsrm:Monzonitic_Rock ;
-.
-gsrm:Quartz_Rich_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "Gillespie and Styles 1999; LeMaitre et al. 2002"@en ;
-  rdfs:comment "Occurrence of igneous rocks meeting this criteria seems to be vanishingly rare, thus subdividing the category does not seem warranted for the purposes of This vocabulary. Future usage of the vocabulary may motivate including quatzolite and quartz-rich granitoid in future revisions"@en ;
-  rdfs:comment "Phaneritic crystalline igneous rock that contains less than 90 percent mafic minerals and contains greater than 60 percent quartz in the QAPF fraction."@en ;
-  rdfs:label "quartz rich igneous rock"@en ;
-  rdfs:subClassOf gsrm:Acidic_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Quartz_Syenite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Syenitic rock that contains between 5 and 20 percent quartz in the QAPF fraction. Defined modally in QAPF Field 7*."@en ;
-  rdfs:label "quartz syenite"@en ;
-  rdfs:subClassOf gsrm:Syenitic_Rock ;
-.
-gsrm:Quartz_Trachyte
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Trachytic rock that contains between 5 and 20 percent quartz in the QAPF fraction. QAPF field 7*."@en ;
-  rdfs:label "quartz trachyte"@en ;
-  rdfs:subClassOf gsrm:Trachytic_Rock ;
-.
-gsrm:Quartzite
-  rdf:type owl:Class ;
-  dct:source "after Neuendorf et al. 2005"@en ;
-  rdfs:comment "Metamorphic rock consisting of greater than or equal to 75 percent quartz; typically granoblastic texture."@en ;
-  rdfs:label "quartzite"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Rhyolite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "rhyolitoid in which the ratio of plagioclase to total feldspar is between 0.1 and 0.65."@en ;
-  rdfs:label "rhyolite"@en ;
-  rdfs:subClassOf gsrm:Rhyolitoid ;
-.
-gsrm:Rhyolitoid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Note that technical definition, based on modal mineralogy plotted in a QAPF triangle may be applied qualitatively, based on phenocryst mineralogy when ground mass mineralogy can not be determined optically, or based on CIPW norm. Although TAS categories are defined based on chemical analyses, the correspondence with the QAPF defined categories is generally close enough that QAPF categories are commonly used interchangeably with TAS categories. It is important to note the basis for assignment of fine-grained igneous rocks to a specifice lithology category."@en ;
-  rdfs:comment "fine_grained_igneous_rock consisting of quartz and alkali feldspar, with minor plagioclase and biotite, in a microcrystalline, cryptocrystalline or glassy groundmass. Flow texture is common. Includes rocks defined modally in QAPF fields 2 and 3 or chemically in TAS Field R as rhyolite. QAPF normative definition is based on modal mineralogy thus: less than 90 percent mafic minerals, between 20 and 60 percent quartz in the QAPF fraction, and ratio of plagioclse to total feldspar is less than 0.65."@en ;
-  rdfs:label "rhyolitoid"@en ;
-  rdfs:subClassOf gsrm:Acidic_Igneous_Rock ;
-  rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
-  skos:altLabel "rhyolitic rock"@en ;
-.
-gsrm:Rock
-  rdf:type owl:Class ;
-  dct:source "Jackson, 1997; NADM C1 2004; Neuendorf et al 2005"@en ;
-  rdfs:comment "Consolidated aggregate of one or more EarthMaterials, or a body of undifferentiated mineral matter, or of solid organic material. Includes mineral aggregates such as granite, shale, marble; glassy matter such as obsidian; and organic material such a coal. Excludes unconsolidated materials."@en ;
-  rdfs:label "rock"@en ;
-  rdfs:subClassOf gsog:Rock_Material ;
-.
-gsrm:Rock_Gypsum_Or_Anhydrite
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Evaporite composed of at least 50 percent gypsum or anhydrite."@en ;
-  rdfs:label "gypsum or anhydrite"@en ;
-  rdfs:subClassOf gsrm:Evaporite ;
-.
-gsrm:Rock_Salt
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Evaporite composed of at least 50 percent halite."@en ;
-  rdfs:label "rock salt"@en ;
-  rdfs:subClassOf gsrm:Evaporite ;
-.
-gsrm:Sand
-  rdf:type owl:Class ;
-  dct:source "definition of sand from SLTTs 2004 sandy sediment; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
-  rdfs:comment "Clastic sediment in which less than 30 percent of particles are gravel (greater than 2 mm in diameter) and the sand to mud ratio is at least 1. More than half of the particles are of epiclastic origin."@en ;
-  rdfs:label "sand"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sediment ;
-  rdfs:subClassOf gsrm:Sand_Size_Sediment ;
-.
-gsrm:Sand_Size_Sediment
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005 ; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
-  rdfs:comment "Sediment in which less than 30 percent of particles are gravel (greater than 2 mm in diameter) and the sand to mud ratio is at least 1. composition or genesis of clasts not specified."@en ;
-  rdfs:label "sand size sediment"@en ;
-  rdfs:subClassOf gsrm:Sediment ;
-.
-gsrm:Sapropel
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005"@en ;
-  rdfs:comment "Jelly like organic rich sediment composed of plant remains, usually algal. Liptinite to Inertinite ratio is greater than one (Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp.)"@en ;
-  rdfs:label "sapropel"@en ;
-  rdfs:subClassOf gsrm:Organic_Rich_Sediment ;
-.
-gsrm:Schist
-  rdf:type owl:Class ;
-  dct:source "SLTTm 2004; Neuendorf et al. 2005"@en ;
-  rdfs:comment "Foliated phaneritic metamorphic rock with well developed, continuous schistosity, meaning that greater than 50 percent of the rock by volume is mineral grains with a thin tabular, lamellar, or acicular prismatic crystallographic habit that are oriented in a continuous planar or linear fabric."@en ;
-  rdfs:label "schist"@en ;
-  rdfs:subClassOf gsrm:Foliated_Metamorphic_Rock ;
-.
-gsrm:Sediment
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Unconsolidated material consisting of an aggregation of particles transported or deposited by air, water or ice, or that accumulated by other natural agents, such as chemical precipitation, and that forms in layers on the Earth's surface. Includes epiclastic deposits."@en ;
-  rdfs:label "sediment"@en ;
-  rdfs:subClassOf gsrm:Natural_Unconsolidated_Material ;
-  rdfs:subClassOf gsrm:Sedimentary_Material ;
-.
-gsrm:Sedimentary_Massive_Sulphide
-  rdf:type owl:Class ;
-  dct:source "smr provisional 2020-06-07"@en ;
-  rdfs:comment "rock consisting of greater than 50% sulphide or sulfosalt minerals formed by sedimentary exhalative processes."@en ;
-  rdfs:label "Sedimentary Massive Sulphide"@en ;
-  rdfs:subClassOf gsrm:Chemical_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Massive_Sulphide ;
-  skos:altLabel "Sedimentary Massive Sulfide"@en ;
-.
-gsrm:Sedimentary_Material
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Material formed by accumulation of solid fragmental material deposited by air, water or ice, or material that accumulated by other natural agents such as chemical precipitation from solution or secretion by organisms. Includes both sediment and sedimentary rock. Includes epiclastic deposits. All stated composition criteria are based on the mineral/ compound material (GeoSciML term)/particulate fraction of the material, irrespective of porosity or the pore-fluid. No distinctions are made based on porosity or pore fluid composition (except organic rich sediment in which liquid hydrocarbon content may be considered)."@en ;
-  rdfs:label "sedimentary material"@en ;
-  rdfs:subClassOf gsog:Rock_Material ;
-.
-gsrm:Sedimentary_Rock
-  rdf:type owl:Class ;
-  dct:source "SLTTs 2004"@en ;
-  rdfs:comment "Rock formed by accumulation and cementation of solid fragmental material deposited by air, water or ice, or as a result of other natural agents, such as precipitation from solution, the accumulation of organic material, or from biogenic processes, including secretion by organisms. Includes epiclastic deposits."@en ;
-  rdfs:label "sedimentary rock"@en ;
-  rdfs:subClassOf gsrm:Rock ;
-  rdfs:subClassOf gsrm:Sedimentary_Material ;
-.
-gsrm:Serpentinite
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005"@en ;
-  rdfs:comment "Rock consisting of more than 75 percent serpentine-group minerals, eg. antigorite, chrysotile or lizardite; accessory chlorite, talc and magnetite may be present; derived from hydration of ferromagnesian silicate minerals such as olivine and pyroxene."@en ;
-  rdfs:label "serpentinite"@en ;
-  rdfs:subClassOf gsrm:Metamorphic_Rock ;
-.
-gsrm:Shale
-  rdf:type owl:Class ;
-  dct:source "NADM SLTT sedimentary, 2004"@en ;
-  rdfs:comment "Laminated mudstone that will part or break along thin, closely spaced layers parallel to stratification."@en ;
-  rdfs:comment "Note definition does not specify carbonate vs. siliclastic nature of mud."@en ;
-  rdfs:label "shale"@en ;
-  rdfs:subClassOf gsrm:Clastic_Mudstone ;
-.
-gsrm:Silicate_Mud
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Mud size sediment that consists of less than 50 percent carbonate minerals."@en ;
-  rdfs:label "silicate mud"@en ;
-  rdfs:subClassOf gsrm:Mud_Size_Sediment ;
-.
-gsrm:Silicate_Mudstone
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Mudstone that contains less than 10 percent carbonate minerals."@en ;
-  rdfs:comment "Operational distinction of this category will typically be based on whether or not the rock fizzes when hydrochloric acid is applied--the rock is silicate mudstone if it does not fizz. The quantitative '10 percent' criteria is fuzzy."@en ;
-  rdfs:label "silicate mudstone"@en ;
-  rdfs:subClassOf gsrm:Generic_Mudstone ;
-.
-gsrm:Siliceous_Ooze
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "ooze that consists of more than 50 percent siliceous skeletal remains"@en ;
-  rdfs:label "siliceous ooze"@en ;
-  rdfs:subClassOf gsrm:Ooze ;
-  rdfs:subClassOf gsrm:Silicate_Mud ;
-.
-gsrm:Silt
-  rdf:type owl:Class ;
-  dct:source "based on SLTTs 2004; Neuendorf et al. 2005; particle size from Wentworth grade scale."@en ;
-  rdfs:comment "Mud that consists of greater than 50 percent silt-size grains. Silt size is between .004 and .063 mm. Note that BGS definition of silt grade is .004 to .032 μm, includes only half if the Wentworth size range. Fortunately, in lithified rocks that have undergone any diagnesis, grain size distinctions in this size range are questionable."@en ;
-  rdfs:label "silt"@en ;
-  rdfs:subClassOf gsrm:Mud ;
-  skos:altLabel "loess"@en ;
-.
-gsrm:Siltstone
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Mudstone that contains detectable silt. (see comments)"@en ;
-  rdfs:comment "Use of 'dectable silt' in the criteria for this category is based on the observation that in practice, distinction of claystone from 'siltstone' is typically based on a qualitative assessment of 'grittiness' (e.g. rubbing with fingers, or chewing); the property that these tests can determine is the presence or absence of silty particles in the material. Quantitative grain size analysis in the the clay/silt fraction of a lithified sediment is difficult at best, and of questionable significance because diagensis has altered the size and mineralogy of original sedimentary particles."@en ;
-  rdfs:label "siltstone"@en ;
-  rdfs:subClassOf gsrm:Clastic_Mudstone ;
-  skos:altLabel "Silt bearing mudstone"@en ;
-.
-gsrm:Skarn
-  rdf:type owl:Class ;
-  dct:source "Fettes and Desmons, 2007, p195"@en ;
-  rdfs:comment "Metasomatic rock consisting mainly of Ca-, Mg-, Fe-, or Mn-silicate minerals, which are free from or poor in water. Typically formed at the contact between a silicate rock or magma and a carbonate rock."@en ;
-  rdfs:label "skarn"@en ;
-  rdfs:subClassOf gsrm:Metasomatic_Rock ;
-  skos:altLabel "exoskarn"@en ;
-  skos:altLabel "tactite"@en ;
-.
-gsrm:Slate
-  rdf:type owl:Class ;
-  dct:source "NADM metamorphic rock vocabulary SLTTm1.0; Neuendorf et al. 2005"@en ;
-  rdfs:comment "compact, fine grained rock with an average grain size less than 0.032 millimeter and a well developed schistosity (slaty cleavage), and hence can be split into slabs or thin plates."@en ;
-  rdfs:label "slate"@en ;
-  rdfs:subClassOf gsrm:Foliated_Metamorphic_Rock ;
-.
-gsrm:Spilite
-  rdf:type owl:Class ;
-  dct:source "Fettes and Desmon, 2007; Best, M.G., 1982, Igneous and metamorphic petrology: New York, W.H. Freeman and company, p. 398; Neuendorf et al. 2005, p. 619."@en ;
-  rdfs:comment "Altered basic to intermediate composition fine-grained igneous rock in which the feldspar is partially or completely composed of of albite, typically accompanied by chlorite, calcite, quartz, epidote, prehnite, and low-tempaerature hydrous crystallization products. Preservation of eruptive volcanic features is typical."@en ;
-  rdfs:label "spilite"@en ;
-  rdfs:subClassOf gsrm:Metasomatic_Rock ;
-.
-gsrm:Syenite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Syenitic rock that contains between 0 and 5 percent quartz and no feldspathoid mineral in the QAPF fraction. Defined modally in QAPF Field 7."@en ;
-  rdfs:label "syenite"@en ;
-  rdfs:subClassOf gsrm:Syenitic_Rock ;
-.
-gsrm:Syenitic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Syenitoid with a plagioclase to total feldspar ratio between 0.1 and 0.35. Includes rocks in QAPF fields 7, 7*, and 7'."@en ;
-  rdfs:label "syenitic rock"@en ;
-  rdfs:subClassOf gsrm:Syenitoid ;
-.
-gsrm:Syenitoid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phaneritic crystalline igneous rock with M less than 90, consisting mainly of alkali feldspar and plagioclase; minor quartz or nepheline may be present, along with pyroxene, amphibole or biotite. Ratio of plagioclase to total feldspar is less than 0.65, quartz forms less than 20 percent of QAPF fraction, and feldspathoid minerals form less than 10 percent of QAPF fraction. Includes rocks classified in QAPF fields 6, 7 and 8 and their subdivisions."@en ;
-  rdfs:label "syenitoid"@en ;
-  rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
-.
-gsrm:Syenogranite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Granite that has a plagiolcase to total feldspar ratio between 0.10 and 0.35. QAPF field 3a."@en ;
-  rdfs:label "syenogranite"@en ;
-  rdfs:subClassOf gsrm:Granite ;
-.
-gsrm:Tephra
-  rdf:type owl:Class ;
-  dct:source "Hallsworth and Knox 1999; LeMaitre et al. 2002"@en ;
-  rdfs:comment "Unconsolidated pyroclastic material in which greater than 75 percent of the fragments are deposited as a direct result of volcanic processes and the deposit has not been reworked by epiclastic processes. Includes ash, lapilli tephra, bomb tephra, block tephra and unconsolidated agglomerate."@en ;
-  rdfs:label "tephra"@en ;
-  rdfs:subClassOf gsrm:Natural_Unconsolidated_Material ;
-  rdfs:subClassOf gsrm:Pyroclastic_Material ;
-.
-gsrm:Tephrite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Tephritoid that has a plagioclase to total feldspar ratio greater than 0.9, and contains less than 10 percent normative (CIPW) olivine."@en ;
-  rdfs:label "tephrite"@en ;
-  rdfs:subClassOf gsrm:Tephritoid ;
-.
-gsrm:Tephritic_Foidite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Foiditoid that contains less than 90 percent feldspathoid minerals in the QAPF fraction, and has a plagioclase to total feldspar ratio that is greater than 0.5, with less than 10 percent normative olivine"@en ;
-  rdfs:label "tephritic foidite"@en ;
-  rdfs:subClassOf gsrm:Foiditoid ;
-.
-gsrm:Tephritic_Phonolite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Phonolitoid that has a plagioclase to total feldspar ratio between 0.1 and 0.5. Broadly corresponds to TAS tephriphonolite of TAS field U3."@en ;
-  rdfs:label "tephritic phonolite"@en ;
-  rdfs:subClassOf gsrm:Phonolitoid ;
-.
-gsrm:Tephritoid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Fine grained igneous rock than contains less than 90 percent mafic minerals, between 10 and 60 percent feldspathoid mineral in the QAPF fraction and has a plagioclase to total feldspar ratio greater than 0.5. Includes rocks classified in QAPF field 13 and 14 or chemically in TAS field U1 as basanite or tephrite."@en ;
-  rdfs:label "tephritoid"@en ;
-  rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
-  skos:altLabel "tephritic rock"@en ;
-.
-gsrm:Tholeiitic_Basalt
-  rdf:type owl:Class ;
-  dct:source "http://en.wikipedia.org/wiki/Basalt; Carmichael, I.S. Turner, F.J., Verhoogen, John, 1974, Igneous petrology: New York, McGraw HIll Book Co., p.42-43."@en ;
-  rdfs:comment "Definition of tholeiite and alkali basalt here are more proscriptive than those found in most reference authorities. This is to actually provide some descriptive criteria to allow assignment of rocks on a hand sample basis to the tholeiite or alkali basalt categories if detailed petrographic or chemical data are available."@en ;
-  rdfs:comment "Tholeiitic basalt is defined here to contain 2 pyroxene phases and interstitial quartz or tridymite or cristobalite in the groundmass. Pyroxene (augite and orthopyroxene or pigeonite) and calcium-rich plagioclase are common phenocryst minerals. Olivine may also be a phenocryst, and when present, may have rims of pigeonite. Only in tholeiitic basalt is olivine in reaction relationship with melt. Interstitial siliceous residue may be present, and is often glassy. Tholeiitic basalt is relatively poor in sodium. This category includes most basalts of the ocean floor, most large oceanic islands, and continental flood basalts such as the Columbia River Plateau."@en ;
-  rdfs:label "tholeiitic basalt"@en ;
-  rdfs:subClassOf gsrm:Basalt ;
-.
-gsrm:Tonalite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Granitoid consisting of quartz and intermediate plagioclase, usually with biotite and amphibole. Includes rocks defined modally in QAPF field 5; ratio of plagioclase to total feldspar is greater than 0.9."@en ;
-  rdfs:label "tonalite"@en ;
-  rdfs:subClassOf gsrm:Granitoid ;
-.
-gsrm:Trachyte
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Trachytoid that has a plagioclase to total feldspar ratio between 0.1 and 0.35, between 0 and 5 percent quartz in the QAPF fraction, and no feldspathoid minerals. QAPF field 7."@en ;
-  rdfs:label "trachyte"@en ;
-  rdfs:subClassOf gsrm:Trachytic_Rock ;
-.
-gsrm:Trachytic_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "LeMaitre et al. (2002) used 'trachyte' to refer to QAPF fields 7, 7', and 7* in the text (p. 30) as well as to the more restrictive category (QAPF field 7 only). The term Trachytic rock is introduced here to label this more general category of trachyte."@en ;
-  rdfs:comment "Trachytoid that has a plagioclase to total feldspar ratio between 0.1 and 0.35. QAPF fields 7, 7', and 7*."@en ;
-  rdfs:label "trachytic rock"@en ;
-  rdfs:subClassOf gsrm:Trachytoid ;
-.
-gsrm:Trachytoid
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002"@en ;
-  rdfs:comment "Fine grained igneous rock than contains less than 90 percent mafic minerals, less than 10 percent feldspathoid mineral and less than 20 percent quartz in the QAPF fraction and has a plagioclase to total feldspar ratio less than 0.65. Mafic minerals typically include amphibole or mica; typically porphyritic. Includes rocks defined modally in QAPF fields 6, 7 and 8 (with subdivisions) or chemically in TAS Field T as trachyte or latite."@en ;
-  rdfs:label "trachytoid"@en ;
-  rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
-.
-gsrm:Travertine
-  rdf:type owl:Class ;
-  dct:source "Neuendorf et al. 2005; http://en.wikipedia.org/wiki/Travertine; Chafetz, H.S., and Folk, R.L., 1984, Travertine: Depositional morphology an dthe bacterially constructed constituents: J. Sed. Petrology, v. 126, p.57-74."@en ;
-  rdfs:comment "Biotically or abiotically precipitated calcium carbonate, from spring-fed, heated, or ambient-temperature water. May be white and spongy, various shades of orange, tan or gray, and ranges to dense, banded or laminated rock. Macrophytes, bryophytes, algae, cyanobacteria and other organisms often colonize the surface of travertine and may be preserved, to produce the porous varieties."@en ;
-  rdfs:label "travertine"@en ;
-  rdfs:subClassOf gsrm:Chemical_Sedimentary_Material ;
-  rdfs:subClassOf gsrm:Limestone ;
-.
-gsrm:Tuff_Breccia_Agglomerate_Or_Pyroclastic_Breccia
-  rdf:type owl:Class ;
-  dct:source "Schmid 1981; LeMaitre et al. 2002"@en ;
-  rdfs:comment "Pyroclastic rock in which greater than 25 percent of particles are greater than 64 mm in largest dimension. Includes agglomerate, pyroclastic breccia of Gillespie and Styles (1999)"@en ;
-  rdfs:label "tuff breccia agglomerate or pyroclastic breccia"@en ;
-  rdfs:subClassOf gsrm:Pyroclastic_Rock ;
-.
-gsrm:Tuffite
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002; Murawski and Meyer 1998"@en ;
-  rdfs:comment "In practice, it is likely that any rock for which there is suspicion that it may consist of redeposited pyroclastic material, usually based on sedimentary structures, irrespective of the presence or percentage of clearly epiclastic particles, would be called a tuffite. 50 percent cutoff with epiclastic rock is in contrast with LeMaitre et al., but is used for consistentency with other sedimentary rock categories following the pattern that the rock name reflects the predominant constituent."@en ;
-  rdfs:comment "Rock consists of more than 50 percent particles of indeterminate pyroclastic or epiclastic origin and less than 75 percent particles of clearly pyroclastic origin. commonly the rock is laminated or exhibits size grading. (based on LeMaitre et al. 2002; Murawski and Meyer 1998)."@en ;
-  rdfs:comment "synonym: volcaniclastic rock" ;
-  rdfs:label "tuffit"@de ;
-  rdfs:label "tuffite"@en ;
-  rdfs:subClassOf gsrm:Rock ;
-.
-gsrm:Ultrabasic_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "after LeMaitre et al. 2002"@en ;
-  rdfs:comment "Igneous rock with less than 45 percent SiO2."@en ;
-  rdfs:label "ultrabasic igneous rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Ultramafic_Igneous_Rock
-  rdf:type owl:Class ;
-  dct:source "LeMaitre et al. 2002; Gillespie and Styles 1999"@en ;
-  rdfs:comment "Igneous rock that consists of greater than 90 percent mafic minerals."@en ;
-  rdfs:label "ultramafic igneous rock"@en ;
-  rdfs:subClassOf gsrm:Igneous_Rock ;
-.
-gsrm:Unconsolidated_Material
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "compoundMaterial composed of an aggregation of particles that do not adhere to each other strongly enough that the aggregate can be considered a solid in its own right."@en ;
-  rdfs:label "unconsolidated material"@en ;
-  rdfs:subClassOf gsog:Rock_Material ;
-.
-gsrm:Wacke
-  rdf:type owl:Class ;
-  dct:source "Pettijohn, Potter, Siever, 1972, Sand and Sandstone: New York, Springer Verlag, 681 p."@en ;
-  rdfs:comment "Clastic sandstone with more than 10 percent matrix of indeterminate detrital or diagenetic nature. Matrix is mud size silicate minerals (clay, feldspar, quartz, rock fragments, and alteration products)."@en ;
-  rdfs:comment "Distinction from mudstone is based on inference that less that 50 percent of the mud size fraction (matrix) is original mud size detrital particles. May also grade into diamictite or conglomerate based on size distribution of discernible particles. If more than 50 percent of rock is detrital particles of intrabasinal orgin and carbonate composition, categorize as carbonate wackestone. Term is typically applied to diagenetically altered volcanic-lithic clastic rocks in which the definition of the original clasts has been obscured. Suggested boundaries between wacke and arenite range from 5 to 15 percent matrix. See Dickinson (1970) for discussion of interpretation of undiscernible matrix in diagenetically altered lithic clastic rocks. Dickinson, W.R., 1970, Interpreting detrital modes of graywacke and arkose: Journal of Sedimentary Petrology, v. 40, p. 695-707."@en ;
-  rdfs:label "piedra"@es ;
-  rdfs:label "wacke"@en ;
-  rdfs:subClassOf gsrm:Clastic_Sandstone ;
-.
-gsrm:advanced_argillic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "Antonio Arribas, Jeffrey Hedenquist, 2019, Environments of advanced argillic alteration: II) steam-heated, and exploration implications: Conference: Society of Resource Geology Annual SymposiumAt: University of Tokyo, Tokyo (Japan)Volume: 69, accessed at https://www.researchgate.net/publication/334230797_Environments_of_advanced_argillic_alteration_II_steam-heated_and_exploration_implications#fullTextFileContent; Constantinos Mavrogonatos et al., 2018, Mineralogical Study of the Advanced Argillic Alteration Zone at the Konos Hill Mo–Cu–Re–Au Porphyry Prospect, NE Greece: Minerals, 8, 479; doi:10.3390/min8110479;  https://en.wikipedia.org/wiki/Argillic_alteration"@en ;
-  rdfs:comment "Advanced argillic alteration occurs under lower pH and higher temperature conditions than argillic alteration. Kaolinite and dickite occur at lower temperatures whereas pyrophyllite and andalusite occur under high temperature conditions (T > 300°C). Quartz deposition is common. Alunite, topaz, zunyite, tourmaline, enargite and tennantite may also occur. In many cases, advanced argillic alteration zones, or “lithocaps”, develop at shallow levels above porphyry Cu–Au deposits (e.g., Lepanto-Far Southeast, Philippines; Maricunga, Chile). Advanced argillic alteration mineral assemblages precipitate from SO2- and HCl-rich magmatic vapor, which arises from an underlying intrusive source, and can also form in supergene environments, due to post-hydrothermal weathering and oxidation of pyrite, locally creating pH<1 liquid due to high concentrations of H2SO4 within the vadose zone, where kaolinite and alunite plus Fe hydroxides form."@en ;
-  rdfs:label "advanced argillic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:albitic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "albitic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:altered_rock
-  rdf:type owl:Class ;
-  rdfs:comment "Rock material has been changed by some subsurface alteration process, but the nature of the alteration is not specified."@en ;
-  rdfs:label "Altered, type not specified "@en ;
-  rdfs:subClassOf gsrm:Metasomatic_Rock ;
-.
-gsrm:alunitic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "alunitic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:any_consolidation
-  rdf:type owl:Class ;
-  dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "In normative descriptions, indicates that consolidation state is not a determining factor in identification, it may have any value."@en ;
-  rdfs:label "consolidation not specified"@en ;
-  rdfs:subClassOf gsrm:Consolidation_Degree_Value ;
-.
-gsrm:argillic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "https://en.wikipedia.org/wiki/Argillic_alteration"@en ;
-  rdfs:comment "Argillic alteration is hydrothermal alteration of wall rock which introduces clay minerals including kaolinite, smectite and illite. The process generally occurs at low temperatures and may occur in atmospheric conditions. Argillic alteration is representative of supergene environments where low temperature groundwater becomes acidic. Argillic assemblages include kaolinite replacing plagioclase and montmorillonite replacing amphibole and plagioclase. Orthoclase is generally stable and unaffected. Argillic grades into phyllic alteration at higher temperatures in an ore deposit hydrothermal system."@en ;
-  rdfs:label "argillic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:bauxite
-  rdf:type owl:Class ;
-  dct:source "Eggleton 2001"@en ;
-  rdfs:comment "Highly aluminous material containing abundant aluminium hydroxides (gibbsite, less commonly boehmite, diaspore) and aluminium-substituted iron oxides or hydroxides and generally minor or negligible kaolin minerals; may contain up to 20 percent quartz. commonly has a pisolitic or nodular texture, and may be cemented."@en ;
-  rdfs:label "bauxite"@en ;
-  rdfs:subClassOf gsrm:material_formed_in_surficial_environment ;
-.
-gsrm:breccia_gouge_series
-  rdf:type owl:Class ;
-  dct:source "SLTTm 2004"@en ;
-  rdfs:comment "Fault-related material with features such as void spaces (filled or unfilled), or unconsolidated matrix material between fragments, indicating loss of cohesion during deformation. Includes fault-related breccia and gouge."@en ;
-  rdfs:label "breccia gouge series"@en ;
-  rdfs:subClassOf gsrm:fault_related_material ;
-.
-gsrm:calcsilicate_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "calcsilicate altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:carbonate_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "carbonate altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:chloritic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "chloritic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:consolidated
-  rdf:type owl:Class ;
-  dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "Particulate constituents of a compound material adhere to each other strongly enough that the aggregate can be considered a solid material in its own right."@en ;
-  rdfs:label "consolidated"@en ;
-  rdfs:subClassOf gsrm:Consolidation_Degree_Value ;
-.
-gsrm:consolidation_variable
-  rdf:type owl:Class ;
-  dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "Consolidation ranges from unconsolidated to indurated on scale of description"@en ;
-  rdfs:label "consolidation variable"@en ;
-  rdfs:subClassOf gsrm:Consolidation_Degree_Value ;
-.
-gsrm:deuteric_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "deuteric altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:epidote_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "epidote altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:fault_related_material
-  rdf:type owl:Class ;
-  dct:source "This vocabulary; SLTTm 2004"@en ;
-  rdfs:comment "Material formed as a result brittle faulting, composed of greater than 10 percent matrix; matrix is fine-grained material caused by tectonic grainsize reduction. Includes cohesive (cataclasite series, mylonitic rocks) and non-cohesive (breccia-gouge series) material."@en ;
-  rdfs:label "fault related material"@en ;
-  rdfs:subClassOf gsrm:Composite_Genesis_Material ;
-.
-gsrm:greisen
-  rdf:type owl:Class ;
-  dct:source "https://en.wikipedia.org/wiki/Greisen"@en ;
-  rdfs:comment "Greisen is a class of endoskarn,  formed by self-generated alteration of a granite. Greisens appear as partly coarse, crystalline granite, partly vuggy with miarolitic cavities, disseminated halide minerals such as fluorite, and occasionally metallic oxide and sulfide ore minerals, borate minerals (tourmaline) and accessory phases such as sphene, beryl or topaz."@en ;
-  rdfs:label "greisen"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:hematitic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "hematitic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:impact_generated_material
-  rdf:type owl:Class ;
-  dct:source "Stöffler and Grieve 2007; Jackson 1997"@en ;
-  rdfs:comment "Material that contains features indicative of shock metamorphism, such as microscopic planar deformation features within grains or shatter cones, interpreted to be the result of extraterrestrial bolide impact. Includes breccias and melt rocks."@en ;
-  rdfs:label "impact generated material"@en ;
-  rdfs:subClassOf gsrm:Composite_Genesis_Material ;
-.
-gsrm:incipient_consolidation
-  rdf:type owl:Class ;
-  dct:source "NADM sedimentary rock vocabulary NADM sedimentary rock vocabulary (https://pubs.usgs.gov/of/2004/1451/sltt/appendixC/appendixC_pdf.zip)  SLTTs 2004,  after Bowles 1986"@en ;
-  rdfs:comment "Shoveled with difficulty, relative density 0.4 - 0.7."@en ;
-  rdfs:label "incipient consolidation"@en ;
-  rdfs:subClassOf gsrm:unconsolidated ;
-.
-gsrm:indurated
-  rdf:type owl:Class ;
-  dct:source "NADM sedimentary rock vocabulary NADM sedimentary rock vocabulary (https://pubs.usgs.gov/of/2004/1451/sltt/appendixC/appendixC_pdf.zip)  SLTTs 2004,  after Bowles 1987"@en ;
-  rdfs:comment "Requires blasting or heavy equipment to loosen, Relative density 0.9-1.0. Rings to blow of hammer."@en ;
-  rdfs:label "indurated"@en ;
-  rdfs:subClassOf gsrm:consolidated ;
-.
-gsrm:kaolinitic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "kaolinitic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:material_formed_in_surficial_environment
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Material that is the product of weathering processes operating on pre-existing rocks or deposits, analogous to hydrothermal or metasomatic rocks, but formed at ambient Earth surface temperature and pressure."@en ;
-  rdfs:label "material formed in surficial environment"@en ;
-  rdfs:subClassOf gsrm:Composite_Genesis_Material ;
-.
-gsrm:moderately_indurated
-  rdf:type owl:Class ;
-  dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "Multiple blows with standard rock hammer (less than 1 kg) are required to break rock."@en ;
-  rdfs:label "moderately indurated"@en ;
-  rdfs:subClassOf gsrm:indurated ;
-.
-gsrm:not_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "Material without any significant secondary alteration."@en ;
-  rdfs:label "material not altered"@en ;
-  rdfs:subClassOf gsrm:Metasomatic_Rock ;
-.
-gsrm:ontology
-  rdf:type owl:Ontology ;
-  dct:bibliographicCitation "Brodaric, B., and Richard, S.M., 2021, The GeoScience Ontology Reference: Geological Survey of Canada Open File 8796, 34 p., https://doi.org/10.4095/328296" ;
-  dct:created "2021-03-26"^^xsd:date ;
-  dct:creator gsoc:boyan_brodaric ;
-  dct:creator gsoc:stephen_richard ;
-  dct:license <https://creativecommons.org/licenses/by/4.0/legalcode> ;
-  dct:modified "2021-03-26"^^xsd:date ;
-  dct:publisher "ARC Loop3D project;  https://loop3d.org/" ;
-  dct:publisher "Geological Survey of Canada, Natural Resources Canada, Government of Canada" ;
-  dct:rights "Copyright (c) 2021 Government of Canada" ;
-  dct:source "<http://resource.geosciml.org/classifierScheme/cgi/2016.01/simplelithology>" ;
-  rdfs:comment "Rock type categories modified from CGI SimpleLithology; properties based on GeoSciML v3.2 conceptual model. Scope includes gso Rock_Material and gso Granular Material. GSO granular material is analogous to GeoSciMLv3.2 compound material particle geometry description.  "@en ;
-  rdfs:label "Geoscience Ontology, Rock Types" ;
-  owl:imports gsoc:ontology ;
-  owl:imports gsog:ontology ;
-  skos:definition "Kinds of rock material."@en ;
-  skos:prefLabel "Geoscience Ontology, Rock Types"@en ;
-  schema:codeRepository "https://github.com/Loop3D/GKM" ;
-.
-gsrm:phyllic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "https://en.wikipedia.org/wiki/Phyllic_alteration"@en ;
-  rdfs:comment "Altered rock characterised by the assemblage of quartz + sericite + pyrite, and occurs at high temperatures and moderately acidic (low pH) conditions. Typically associated with copper porphyry ore deposits in calc-alkaline rocks."@en ;
-  rdfs:label "phyllic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:potassic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "potassic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:propylitic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "propylitic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:pyritic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "pyritic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:red_rock_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  dct:source "Williams, P.J., 1994, Aust. J. Earth Science, v41, p381-382" ;
-  rdfs:comment "Alteration characterized by finely dispersed hematite"@en ;
-  rdfs:label "red rock altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:residual_material
-  rdf:type owl:Class ;
-  dct:source "This vocabulary"@en ;
-  rdfs:comment "Material of composite origin resulting from weathering processes at the Earth's surface, with genesis dominated by removal of chemical constituents by aqueous leaching. Miinor clastic, chemical, or organic input may also contribute. Consolidation state is not inherent in definition, but typically material is unconsolidated or weakly consolidated."@en ;
-  rdfs:label "residual material"@en ;
-  rdfs:subClassOf gsrm:material_formed_in_surficial_environment ;
-.
-gsrm:saussuritised_rock
-  rdf:type owl:Class ;
-  dct:source "https://www.britannica.com/science/saussuritization"@en ;
-  rdfs:comment "Rock in which calcium-bearing plagioclase feldspar is altered to an assemblage of minerals called saussurite, typically including zoisite, chlorite, amphibole, and carbonate minerals. Residual fluids present during the late stages of magmatic crystallization can react with previously formed plagioclase feldspar to form saussurite; the saussurite will be spread through the plagioclase or located near its outer margin. The plagioclase may be reconstituted into a more sodium-rich variety (albite), although the original form of the crystal is retained. Later hydrothermal alteration can produce the same result. Mafic rocks are especially susceptible to saussuritization owing to their high calcium content; the more calcium-rich portions of plagioclase in acidic rocks also are often saussuritized."@en ;
-  rdfs:label "saussuritised rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:sericitic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "https://en.wikipedia.org/wiki/Sericitic_alteration"@en ;
-  rdfs:comment "Rock in which plagioclase feldspar has been converted to sericite, an informal term for  fine-grained white phyllosilicate minerals. Commonly associated with phyllic altered rocks, used to describe less intense alteration."@en ;
-  rdfs:label "sericitic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:serpentinised_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "serpentinised rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:silicified_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "silicificed rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:slightly_indurated
-  rdf:type owl:Class ;
-  dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "Rock can be broken with single blow from standard rock hammer (less than 1 kg mass)."@en ;
-  rdfs:label "slightly indurated"@en ;
-  rdfs:subClassOf gsrm:indurated ;
-.
-gsrm:unconsolidated
-  rdf:type owl:Class ;
-  dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "Particulate constituents of a compound material do not adhere to each other strongly enough that the aggregate can be considered a solid in its own right."@en ;
-  rdfs:label "unconsolidated"@en ;
-  rdfs:subClassOf gsrm:Consolidation_Degree_Value ;
-.
-gsrm:unconsolidated_loose
-  rdf:type owl:Class ;
-  dct:source "NADM sedimentary rock vocabulary NADM sedimentary rock vocabulary (https://pubs.usgs.gov/of/2004/1451/sltt/appendixC/appendixC_pdf.zip)  SLTTs 2004,  after Bowles 1985"@en ;
-  rdfs:comment "Easily shoveled, can be indented with fingers, Relative density 0.2-0.4."@en ;
-  rdfs:label "unconsolidated loose"@en ;
-  rdfs:subClassOf gsrm:unconsolidated ;
-.
-gsrm:unconsolidated_very_loose
-  rdf:type owl:Class ;
-  dct:source "NADM sedimentary rock vocabulary NADM sedimentary rock vocabulary (https://pubs.usgs.gov/of/2004/1451/sltt/appendixC/appendixC_pdf.zip)  SLTTs 2004,  after Bowles 1984"@en ;
-  rdfs:comment "Easily indented with fingers, Relative density 0.0-0.2."@en ;
-  rdfs:label "unconsolidated very loose"@en ;
-  rdfs:subClassOf gsrm:unconsolidated ;
-.
-gsrm:uralitised_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "uralitised rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
-gsrm:variable_induration
-  rdf:type owl:Class ;
-  dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "Material is lithified, but induration varies at scale of description."@en ;
-  rdfs:label "variable induration"@en ;
-  rdfs:subClassOf gsrm:indurated ;
-.
-gsrm:well_consolidated
-  rdf:type owl:Class ;
-  dct:source "NADM sedimentary rock vocabulary NADM sedimentary rock vocabulary (https://pubs.usgs.gov/of/2004/1451/sltt/appendixC/appendixC_pdf.zip)  SLTTs 2004,  after Bowles 1986"@en ;
-  rdfs:comment "Requires pick to loosen for shoveling, relative density 0.7-0.9."@en ;
-  rdfs:label "well consolidated"@en ;
-  rdfs:subClassOf gsrm:consolidated ;
-.
-gsrm:well_indurated
-  rdf:type owl:Class ;
-  dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "Particles in the rock are strongly bound together such that rock surface can only be broken with great difficulty using standard rock hammer (less than 1 kg mass)."@en ;
-  rdfs:label "well indurated"@en ;
-  rdfs:subClassOf gsrm:indurated ;
-.
-gsrm:zeolitic_altered_rock
-  rdf:type owl:Class ;
-  dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
-  rdfs:comment "definition missing"@en ;
-  rdfs:label "zeolitic altered rock"@en ;
-  rdfs:subClassOf gsrm:altered_rock ;
-.
+gsoc:boyan_brodaric a owl:NamedIndividual,
+        schema:Person ;
+    rdfs:label "Dr. Boyan Brodaric" ;
+    rdfs:comment "e-mail: mailto:boyan.brodaric@canada.ca " ;
+    schema:affiliation "Natural Resources Canada, Geological Survey of Canada" ;
+    schema:identifier <https://orcid.org/0000-0002-7987-3810> ;
+    schema:name "Dr. Boyan Brodaric" .
+
+gsoc:stephen_richard a owl:NamedIndividual,
+        schema:Person ;
+    rdfs:label "Dr. Stephen M. Richard" ;
+    rdfs:comment "e-mail: mailto:smrTucson@gmail.com " ;
+    schema:identifier <https://orcid.org/0000-0001-6041-5302> ;
+    schema:name "Dr. Stephen M. Richard" .
+
+gsrm:Alkali-Olivine_Basalt a owl:Class ;
+    rdfs:label "alkali olivine basalt"@en ;
+    dct:source "http://en.wikipedia.org/wiki/Basalt; Carmichael, I.S. Turner, F.J., Verhoogen, John, 1974, Igneous petrology: New York, McGraw HIll Book Co., p.42-43."@en ;
+    rdfs:comment "Alkali olivine basalt is silica-undersaturated, characterized by the absence of orthopyroxene, absence of quartz, presence of olivine, and typically contains some feldspathoid mineral, alkali feldspar or phlogopite in the groundmass. Feldspar phenocrysts typically are labradorite to andesine in composition. Augite is rich in titanium compared to augite in tholeiitic basalt. Alkali olivine basalt is relatively rich in sodium."@en,
+        "The definition of tholeiite and alkali basalt here are more prescriptive than those found in most reference authorities. This is to actually provide some descriptive criteria to allow assignment of rocks on a hand sample basis to the tholeiite or alkali basalt categories if detailed petrographic or chemical data are available."@en ;
+    rdfs:subClassOf gsrm:Basalt ;
+    gsmin:mindatid "min-53210" ;
+    gsmin:mindaturl "https://mindat.org/min-53210.html" .
+
+gsrm:Alkali_Feldspar_Granite a owl:Class ;
+    rdfs:label "alkali feldspar granite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Granitic rock that has a plagioclase to total feldspar ratio less than 0.1. QAPF field 2."@en ;
+    rdfs:subClassOf gsrm:Granitoid .
+
+gsrm:Alkali_Feldspar_Rhyolite a owl:Class ;
+    rdfs:label "alkali feldspar rhyolite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Rhyolitoid in which the ratio of plagioclase to total feldspar is less than 0.1. QAPF field 2."@en ;
+    rdfs:subClassOf gsrm:Rhyolitoid .
+
+gsrm:Alkali_Feldspar_Syenite a owl:Class ;
+    rdfs:label "alkali feldspar syenite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Alkali feldspar syenitic rock that contains 0-5 percent quartz and no feldspathoid in the QAPF fraction. QAPF field 6."@en ;
+    rdfs:subClassOf gsrm:Alkali_Feldspar_Syenitic_Rock .
+
+gsrm:Alkali_Feldspar_Trachyte a owl:Class ;
+    rdfs:label "alkali feldspar trachyte"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Trachytoid that has a plagioclase to total feldspar ratio less than 0.1, between 0 and 5 percent quartz in the QAPF fraction, and no feldspathoid minerals. QAPF field 6."@en ;
+    rdfs:subClassOf gsrm:Alkali_Feldspar_Trachytic_Rock .
+
+gsrm:Amphibolite a owl:Class ;
+    rdfs:label "amphibolite"@en ;
+    dct:source "Coutinho et al. 2007, IUGS SCMR chapter 8 (http://www.bgs.ac.uk/SCMR/)"@en ;
+    rdfs:comment "Metamorphic rock mainly consisting of green, brown or black amphibole and plagioclase (including albite), which combined form 75 percent or more of the rock, and both of which are present as major constituents. The amphibole constitutes 50 percent or more of the total mafic constituents and is present in an amount of 30 percent or more; other common minerals include quartz, clinopyroxene, garnet, epidote-group minerals, biotite, titanite and scapolite."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-48627" ;
+    gsmin:mindaturl "https://mindat.org/min-48627.html" .
+
+gsrm:Anorthosite a owl:Class ;
+    rdfs:label "anorthosite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Anorthositic rock that contains between 0 and 5 percent quartz and no feldspathoid mineral in the QAPF fraction. QAPF field 10."@en ;
+    rdfs:subClassOf gsrm:Anorthositic_Rock ;
+    gsmin:mindatid "min-48323" ;
+    gsmin:mindaturl "https://mindat.org/min-48323.html" .
+
+gsrm:Anthracite_Coal a owl:Class ;
+    rdfs:label "anthrazit"@de,
+        "anthracite"@en ;
+    dct:source "Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp; see also Neuendorf et al. 2005; http://en.wikipedia.org/wiki/Coal#Types_of_coal; Eberhard Lindner; Chemie für Ingenieure; Lindner Verlag Karlsruhe, S. 258"@en ;
+    rdfs:comment "Coal that has vitrinite mean random reflectance greater than 2.0% (determined in conformance with ISO 7404-5). Less than 12-14 percent volatiles (dry, ash free), greater than 91 percent fixed carbon (dry, ash free basis). The highest rank coal; very hard, glossy, black, with semimetallic luster, semi conchoidal fracture."@en ;
+    rdfs:subClassOf gsrm:Coal ;
+    skos:altLabel "High rank coal"@en ;
+    gsmin:mindatid "min-9434" ;
+    gsmin:mindaturl "https://mindat.org/min-9434.html" .
+
+gsrm:Anthropogenic_Unconsolidated_Material a owl:Class ;
+    rdfs:label "anthropogenic unconsolidated material"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Unconsolidated material known to have artificial (human-related) origin."@en ;
+    rdfs:subClassOf gsrm:Anthropogenic_Material,
+        gsrm:Unconsolidated_Material .
+
+gsrm:Aphanite a owl:Class ;
+    rdfs:label "aphanite"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Rock that is too fine grained to categorize in more detail."@en ;
+    rdfs:subClassOf gsrm:Rock ;
+    gsmin:mindatid "min-50628" ;
+    gsmin:mindaturl "https://mindat.org/min-50628.html" .
+
+gsrm:Aplite a owl:Class ;
+    rdfs:label "aplite"@en ;
+    dct:source "Neuendorf et al. 2005"@en ;
+    rdfs:comment "Light coloured crystalline rock, characterized by a fine grained allotriomorphic-granular (aplitic, saccharoidal or xenomorphic) texture; typically granitic composition, consisting of quartz, alkali feldspar and sodic plagioclase."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
+    gsmin:mindatid "min-50505" ;
+    gsmin:mindaturl "https://mindat.org/min-50505.html" .
+
+gsrm:Arenite a owl:Class ;
+    rdfs:label "arenit"@de,
+        "arenite"@en ;
+    dct:source "Pettijohn, Potter, Siever, 1972, Sand and Sandstone: New York, Springer Verlag, 681 p."@en ;
+    rdfs:comment "Clastic sandstone that contains less than 10 percent matrix. Matrix is mud-size silicate minerals (clay, feldspar, quartz, rock fragments, and alteration products) of detrital or diagenetic nature."@en ;
+    rdfs:subClassOf gsrm:Clastic_Sandstone ;
+    gsmin:mindatid "min-49440" ;
+    gsmin:mindaturl "https://mindat.org/min-49440.html" .
+
+gsrm:Argillite a owl:Class ;
+    rdfs:label "Argillite "@en ;
+    dct:source "Neuendorf et al, 2004, provisional SMR 2020-06-11"@en ;
+    rdfs:comment "A weakly metamorphosed argillaceous rock (Flawn, 1953, AAPG Bull v37 p.563-664).  Rock is very fine-grained to aphanitic, compact, indurated, and massive (lacks fissility or cleavage) (Neuendorf et al, 2004). Claystone and Siltstone are related, non-metamorphosed sedimentary rocks. Like Aphanite but sedimentary protolith is determined. In contact metamorphic environments would be Hornfels."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock .
+
+gsrm:Ash_And_Lapilli a owl:Class ;
+    rdfs:label "ash and lapilli"@en ;
+    dct:source "Schmid 1981; LeMaitre et al. 2002"@en ;
+    rdfs:comment "Tephra in which less than 25 percent of fragments are greater than 64 mm in longest dimension"@en ;
+    rdfs:subClassOf gsrm:Tephra .
+
+gsrm:Ash_Breccia_Bomb_Or_Block_Tephra a owl:Class ;
+    rdfs:label "ash breccia bomb or block tephra"@en ;
+    dct:source "Schmid 1981; LeMaitre et al. 2002"@en ;
+    rdfs:comment "Tephra in which more than 25 percent of particles are greater than 64 mm in largest dimension. Includes ash breccia, bomb tephra and block tephra of Gillespie and Styles (1999)"@en ;
+    rdfs:subClassOf gsrm:Tephra .
+
+gsrm:Ash_Tuff_Lapillistone_And_Lapilli_Tuff a owl:Class ;
+    rdfs:label "ash tuff lapillistone and lapilli tuff"@en ;
+    dct:source "Schmid 1981; LeMaitre et al. 2002"@en ;
+    rdfs:comment "Pyroclastic rock in which less than 25 percent of rock by volume are more than 64 mm in longest diameter. Includes tuff, lapilli tuff, and lapillistone."@en ;
+    rdfs:subClassOf gsrm:Pyroclastic_Rock .
+
+gsrm:Basanite a owl:Class ;
+    rdfs:label "basanite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Tephritoid that has a plagioclase to total feldspar ratio greater than 0.9, and contains more than 10 percent normative (CIPW) olivine."@en ;
+    rdfs:subClassOf gsrm:Tephritoid ;
+    gsmin:mindatid "min-9173" ;
+    gsmin:mindaturl "https://mindat.org/min-9173.html" .
+
+gsrm:Basanitic_Foidite a owl:Class ;
+    rdfs:label "basanitic foidite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Foiditoid that contains less than 90 percent feldspathoid minerals in the QAPF fraction, and has a plagioclase to total feldspar ratio that is greater than 0.5, with greater than 10 percent normative olivine."@en ;
+    rdfs:subClassOf gsrm:Foiditoid .
+
+gsrm:Biogenic_Silica_Sedimentary_Rock a owl:Class ;
+    rdfs:label "biogenic silica sedimentary rock"@en ;
+    dct:source "based on NADM SLTT sedimentary; Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Sedimentary rock that consists of at least 50 percent silicate mineral material, deposited directly by biological processes at the depositional surface, or in particles formed by biological processes within the basin of deposition. Includes radiolarian chert, diatomite, novaculite."@en ;
+    rdfs:subClassOf gsrm:Non_Clastic_Siliceous_Sedimentary_Rock .
+
+gsrm:Bituminous_Coal a owl:Class ;
+    rdfs:label "bituminous coal"@en ;
+    dct:source "Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp; see also http://en.wikipedia.org/wiki/Coal#Types_of_coal; Eberhard Lindner; Chemie für Ingenieure; Lindner Verlag Karlsruhe, S. 258"@en ;
+    rdfs:comment "Coal that has vitrinite mean random reflectance greater than 0.6% and less than 2.0% (determined in conformance with ISO 7404-5), or has a gross calorific value greater than 24 MJ/kg (determined in conformance with ISO 1928). Hard, black, organic rich sedimentary rock; contains less than 91 percent fixed carbon on a dry, mineral-matter-free basis, and greater than 13-14 percent volatiles (dry, ash free). Formed from the compaction or induration of variously altered plant remains similar to those of peaty deposits."@en ;
+    rdfs:subClassOf gsrm:Coal ;
+    skos:altLabel "medium rank coal"@en .
+
+gsrm:Boninite a owl:Class ;
+    rdfs:label "boninite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "andesitic rock that contains more than 8 percent MgO. Typically consists of phenocrysts of protoenstatite, orthopyroxene, clinopyroxene, and olivine in a glassy base full of crystallites, and exhibits textures characterisitc of rapid crystal growth."@en ;
+    rdfs:subClassOf gsrm:Andesite,
+        gsrm:High_Magnesium_Fine_Grained_Igneous_Rock ;
+    gsmin:mindatid "min-48490" ;
+    gsmin:mindaturl "https://mindat.org/min-48490.html" .
+
+gsrm:Boulder_Gravel_Size_Sediment a owl:Class ;
+    rdfs:label "boulder gravel size sediment"@en ;
+    dct:source "Wentworth size scale"@en ;
+    rdfs:comment "Sediment containing greater than 30 percent boulder-size particles (greater than 256 mm in diameter)"@en ;
+    rdfs:subClassOf gsrm:Gravel_Size_Sediment .
+
+gsrm:Boundstone a owl:Class ;
+    rdfs:label "boundstone"@en ;
+    dct:source "Hallsworth and Knox 1999; SLTTs 2004"@en ;
+    rdfs:comment "Sedimentary carbonate rock with preserved biogenic texture, whose original components were bound and encrusted together during deposition by the action of plants and animals during deposition, and remained substantially in the position of growth."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
+    gsmin:mindatid "min-50887" ;
+    gsmin:mindaturl "https://mindat.org/min-50887.html" .
+
+gsrm:Breccia a owl:Class ;
+    rdfs:label "breccia"@en ;
+    dct:source "Neuendorf et al. 2005"@en ;
+    rdfs:comment "Coarse-grained material composed of angular broken rock fragments; the fragments typically have sharp edges and unworn corners. The fragments may be held together by a mineral cement or in a fine-grained matrix, and consolidated or nonconsolidated. Clasts may be of any composition or origin. In sedimentary environments, breccia is used for material that consists entirely of angular fragments, mostly derived from a single source rock body, as in a rock avalanche deposit, and matrix is interpreted to be the product of comminution of clasts during transport. Diamictite or diamicton is used when the material reflects mixing of rock from a variety of sources, some sub angular or subrounded clasts may be present, and matrix is pre-existing fine grained material that is not a direct product of the brecciation/deposition process."@en ;
+    rdfs:subClassOf gsog:Rock_Material .
+
+gsrm:Carbonate_Mudstone a owl:Class ;
+    rdfs:label "carbonate mudstone"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Mudstone that consists of greater than 50 percent carbonate minerals of any origin in the mud size fraction."@en,
+        "Not a subcategory of carbonate sedimentary rock because definition does not specify 'carbonate minerals of intrabasinal origin', but is agnostic on origin of carbonate. Schnurrenberger et al. 2003 point out that it is very difficult (at least in lacustrine rocks) to distinguish chemically precipitated or diagenetic carbonate from primary biogenic carbonate. This distinction between biogenic, detrital, and pedogenic or authigenic carbonate material is thus not a good one to use in a general purpose classification system. Schnurrenberger, D., Russell, J. and Kelts, K., 2003, Classification of lacustrine sediments based on sedimentary components: Journal of Paleolimnology, v.29, p141-154."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock,
+        gsrm:Generic_Mudstone ;
+    skos:altLabel "marlstone"@en .
+
+gsrm:Carbonate_Ooze a owl:Class ;
+    rdfs:label "carbonate ooze"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "ooze that consists of more than 50 percent carbonate skeletal remains"@en ;
+    rdfs:subClassOf gsrm:Carbonate_Mud,
+        gsrm:Ooze .
+
+gsrm:Carbonate_Rich_Mud a owl:Class ;
+    rdfs:label "carbonate rich mud"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Mud size sediment that contains between 10 and 50 percent carbonate minerals in any size fraction. Carbonate origin is not specified."@en ;
+    rdfs:subClassOf gsrm:Mud_Size_Sediment ;
+    skos:altLabel "carbonate rich loess"@en,
+        "marl"@en .
+
+gsrm:Carbonate_Rich_Mudstone a owl:Class ;
+    rdfs:label "carbonate rich mudstone"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Carbonate-rich mudstone' definition limits carbonate to mud-size fraction to avoid overlap with 'impure carbonate sedimentary rock'. If carbonate minerals are in sand or gravel size fractions, use 'impure carbonate sedimentary rock'. The operational test typically used to identify this category is if the rock fizzes when hydrochloric acid is applied. The '10 percent carbonate' criteria is a fuzzy boundary."@en,
+        "Mudstone that contains between 10 and 50 percent carbonate minerals in the mud size fraction. Carbonate origin is not specified."@en ;
+    rdfs:subClassOf gsrm:Generic_Mudstone ;
+    skos:altLabel "marlstone"@en .
+
+gsrm:Carbonate_Wackestone a owl:Class ;
+    rdfs:label "carbonate wackestone"@en ;
+    dct:source "Dunham 1962"@en ;
+    rdfs:comment "Carbonate sedimentary rock with discernible mud supported depositional texture and containing greater than 10 percent allochems, and constituent particles are of intrabasinal origin. If particles are not intrabasinal, categorization as a mudstone or wackestone should be considered."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock .
+
+gsrm:Carbonatite a owl:Class ;
+    rdfs:label "carbonatite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous rock composed of more than 50 percent modal carbonate minerals."@en ;
+    rdfs:subClassOf gsrm:Exotic_Composition_Igneous_Rock ;
+    gsmin:mindatid "min-48019" ;
+    gsmin:mindaturl "https://mindat.org/min-48019.html" .
+
+gsrm:Cataclasite_Series a owl:Class ;
+    rdfs:label "cataclasite series"@en ;
+    dct:source "Sibson, 1977; Scholz, 1990; Snoke and Tullis, 1998; Barker, 1998 Appendix II; NADM SLTTm, 2004"@en ;
+    rdfs:comment "Fault-related rock that maintained primary cohesion during deformation, with matrix comprising greater than 10 percent of rock mass; matrix is fine-grained material formed through grain size reduction by fracture as opposed to crystal plastic process that operate in mylonitic rock. Includes cataclasite, protocataclasite and ultracataclasite."@en ;
+    rdfs:subClassOf gsrm:Composite_Genesis_Rock,
+        gsrm:fault_related_material ;
+    gsmin:mindatid "min-48673" ;
+    gsmin:mindaturl "https://mindat.org/min-48673.html" .
+
+gsrm:Chalk a owl:Class ;
+    rdfs:label "chalk"@en ;
+    dct:source "http://en.wikipedia.org/wiki/Chalk; C.S. Harris, 2009, unpublished web page, http://www.geologyshop.co.uk/chalk.htm"@en ;
+    rdfs:comment "A generally soft, white, very fine-grained, extremely pure, porous limestone. It forms under marine conditions from the gradual accumulation of skeletal elements from minute planktonic green algae (cocoliths), associated with varying proportions of larger microscopic fragments of bivalves, foraminifera and ostracods. It is common to find flint and chert nodules embedded in chalk."@en ;
+    rdfs:subClassOf gsrm:Limestone ;
+    gsmin:mindatid "min-9073" ;
+    gsmin:mindaturl "https://mindat.org/min-9073.html" .
+
+gsrm:Chlorite_Actinolite_Epidote_Metamorphic_Rock a owl:Class ;
+    rdfs:label "chlorite actinolite epidote metamorphic rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Metamorphic rock characterized by 50 percent or more of combined chlorite, actinolite and epidote. Category for rocks generally named greenschist or greenstone."@en,
+        "Rock classified as Greenschist is difficult to categorize in the CGI SimpleLithology scheme. This stems in part from the variation in usage and the general fuzzy definition of the term. The definition of greenschist is generally something along the lines of 'metamorphosed rock with a greenish colour, characterized by the presence of actinolite, chlorite and epidote, and containing a planar or linear fabric. The presence or absence of schistose fabric in rocks called 'greenschist' is problematic. The fabric present in many rocks called greenschist is too weak or variably developed to meet the definition of 'schist' per CGI SimpleLithology. Generally if the rock has achieved metamorphic grade such that the term 'gneiss' is applicable, it would not be called greenschist. Thus, 'greenschist' would correspond most closely to a chlorite + actinolite rich 'Foliated metamorphic rock', but if it actually meets the definition of 'Schist' it would be a chlorite + actinolite 'Schist'."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock .
+
+gsrm:Clastic_Conglomerate a owl:Class ;
+    rdfs:label "conglomerate"@en ;
+    dct:source "Neuendorf et al. 2005; SLTTs 2004"@en ;
+    rdfs:comment "Clastic sedimentary rock composed of at least 30 percent rounded to subangular fragments larger than 2 mm in diameter; typically contains finer grained material in interstices between larger fragments. If more than 15 percent of the fine grained matrix is of indeterminant clastic or diagenetic origin and the fabric is matrix supported, may also be categorized as wackestone. If rock has unsorted or poorly sorted texture with a wide range of particle sizes, may also be categorized as diamictite."@en,
+        "Note this category is equivlanet to category labeled 'Conglomeratic rock in SLTTs (2004), not to the category labeled 'Conglomerate' in that system."@en ;
+    rdfs:subClassOf gsrm:Clastic_Sedimentary_Rock,
+        gsrm:Generic_Conglomerate ;
+    skos:altLabel "conglomeratic rock"@en ;
+    gsmin:mindatid "min-49436" ;
+    gsmin:mindaturl "https://mindat.org/min-49436.html" .
+
+gsrm:Clay a owl:Class ;
+    rdfs:label "clay"@en ;
+    dct:source "based on SLTTs 2004; Neuendorf et al. 2005; particle size from Wentworth grade scale"@en ;
+    rdfs:comment "Mud that consists of greater than 50 percent particles with grain size less than 0.004 mm"@en ;
+    rdfs:subClassOf gsrm:Mud ;
+    gsmin:mindatid "min-52526" ;
+    gsmin:mindaturl "https://mindat.org/min-52526.html" .
+
+gsrm:Claystone a owl:Class ;
+    rdfs:label "claystone"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Mudstone that contains no detectable silt, inferred to consist virtually entirely of clay-size particles."@en ;
+    rdfs:subClassOf gsrm:Clastic_Mudstone ;
+    gsmin:mindatid "min-49446" ;
+    gsmin:mindaturl "https://mindat.org/min-49446.html" .
+
+gsrm:Cobble_Gravel_Size_Sediment a owl:Class ;
+    rdfs:label "cobble gravel size sediment"@en ;
+    dct:source "Wentworth size scale"@en ;
+    rdfs:comment "Sediment containing greater than 30 percent cobble-size particles (64-256 mm in diameter)"@en ;
+    rdfs:subClassOf gsrm:Gravel_Size_Sediment .
+
+gsrm:Crystalline_Carbonate a owl:Class ;
+    rdfs:label "crystalline carbonate"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Carbonate rock of indeterminate mineralogy in which diagenetic processes have obliterated any original depositional texture."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock .
+
+gsrm:Dacite a owl:Class ;
+    rdfs:label "dacite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Fine grained or porphyritic crystalline rock that contains less than 90 percent mafic minerals, between 20 and 60 percent quartz in the QAPF fraction, and has a plagioclase to total feldspar ratio greater than 0.65. Includes rocks defined modally in QAPF fields 4 and 5 or chemically in TAS Field O3. Typically composed of quartz and sodic plagioclase with minor amounts of biotite and/or hornblende and/or pyroxene; fine-grained equivalent of granodiorite and tonalite."@en ;
+    rdfs:subClassOf gsrm:Acidic_Igneous_Rock,
+        gsrm:Fine_Grained_Igneous_Rock ;
+    gsmin:mindatid "min-48447" ;
+    gsmin:mindaturl "https://mindat.org/min-48447.html" .
+
+gsrm:Diamictite a owl:Class ;
+    rdfs:label "diamictite"@en ;
+    dct:source "Fairbridge and Bourgeois 1978"@en ;
+    rdfs:comment "Unsorted or poorly sorted, clastic sedimentary rock with a wide range of particle sizes including a muddy matrix. Biogenic materials that have such texture are excluded. Distinguished from conglomerate, sandstone, mudstone based on polymodality and lack of structures related to transport and deposition of sediment by moving air or water. If more than 10 percent of the fine grained matrix is of indeterminant clastic or diagenetic origin and the fabric is matrix supported, may also be categorized as wacke."@en ;
+    rdfs:subClassOf gsrm:Clastic_Sedimentary_Rock ;
+    gsmin:mindatid "min-49449" ;
+    gsmin:mindaturl "https://mindat.org/min-49449.html" .
+
+gsrm:Diamicton a owl:Class ;
+    rdfs:label "diamicton"@en ;
+    dct:source "Fairbridge and Bourgeois 1978"@en ;
+    rdfs:comment "Unsorted or poorly sorted, clastic sediment with a wide range of particle sizes, including a muddy matrix. Biogenic materials that have such texture are excluded. Distinguished from conglomerate, sandstone, mudstone based on polymodality and lack of structures related to transport and deposition of sediment by moving air or water. Assignment to an other size class can be used in conjunction to indicate the dominant grain size."@en,
+        "definition amplified to help distinguish diamicton, conglomerate and wackestone in this version"@en ;
+    rdfs:subClassOf gsrm:Clastic_Sediment ;
+    gsmin:mindatid "min-49434" ;
+    gsmin:mindaturl "https://mindat.org/min-49434.html" .
+
+gsrm:Diorite a owl:Class ;
+    rdfs:label "diorite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline rock consisting of intermediate plagioclase, commonly with hornblende and often with biotite or augite; colour index M less than 90, sodic plagioclase (An0-An50), no feldspathoid, and between 0 and 5 percent quartz. Includes rocks defined modally in QAPF field 10 as diorite."@en ;
+    rdfs:subClassOf gsrm:Dioritic_Rock ;
+    gsmin:mindatid "min-48226" ;
+    gsmin:mindaturl "https://mindat.org/min-48226.html" .
+
+gsrm:Doleritic_Rock a owl:Class ;
+    rdfs:label "doleritic rock"@en ;
+    dct:source "Neuendorf et al 2005; LeMaitre et al. 2002; Gillespie and Styles 1999"@en ;
+    rdfs:comment "Dark colored gabbroic (basaltic) or dioritic (andesitic) rock intermediate in grain size between basalt and gabbro and composed of plagioclase, pyroxene and opaque minerals; often with ophitic texture. Typically occurs as hypabyssal intrusions. Includes dolerite, microdiorite, diabase and microgabbro."@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock .
+
+gsrm:Dolostone a owl:Class ;
+    rdfs:label "dolomite"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Pure carbonate sedimentary rock with a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1."@en ;
+    rdfs:subClassOf gsrm:Dolomitic_Or_Magnesian_Sedimentary_Rock,
+        gsrm:Pure_Carbonate_Sedimentary_Rock ;
+    skos:altLabel "dolostone"@en,
+        "pure dolomitic or magnesian carbonate sedimentary rock"@en .
+
+gsrm:Duricrust a owl:Class ;
+    rdfs:label "duricrust"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Rock forming a hard crust or layer at or near the Earth's surface at the time of formation, e.g. in the upper horizons of a soil, characterized by structures indicative of pedogenic origin."@en ;
+    rdfs:subClassOf gsrm:Composite_Genesis_Rock,
+        gsrm:material_formed_in_surficial_environment ;
+    gsmin:mindatid "min-50909" ;
+    gsmin:mindaturl "https://mindat.org/min-50909.html" .
+
+gsrm:Eclogite a owl:Class ;
+    rdfs:label "eclogite"@en ;
+    dct:source "IUGS SCMR 2007 (http://www.bgs.ac.uk/SCMR/)"@en ;
+    rdfs:comment "Metamorphic rock composed of 75 percent or more (by volume) omphacite and garnet, both of which are present as major constituents, the amount of neither of them being higher than 75 percent (by volume); the presence of plagioclase precludes classification as an eclogite."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-48628" ;
+    gsmin:mindaturl "https://mindat.org/min-48628.html" .
+
+gsrm:Exotic_Alkaline_Rock a owl:Class ;
+    rdfs:label "exotic alkaline rock"@en ;
+    dct:source "based on LeMaitre et al. 2002"@en ;
+    rdfs:comment "Kimberlite, lamproite, or lamprophyre. Generally are potassic, mafic or ultramafic rocks. Olivine (commonly serpentinized in kimberlite), and phlogopite are significant constituents."@en ;
+    rdfs:subClassOf gsrm:Exotic_Composition_Igneous_Rock .
+
+gsrm:Exotic_Evaporite a owl:Class ;
+    rdfs:label "exotic evaporite"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Category represents evaporite material that is not mostly gypsum/anhydrite or halite. These are generally not very common, thus the 'exotic' name"@en,
+        "Evaporite that is not 50 percent halite or 50 percent gypsum or anhydrite."@en ;
+    rdfs:subClassOf gsrm:Evaporite .
+
+gsrm:Foid_Bearing_Alkali_Feldspar_Syenite a owl:Class ;
+    rdfs:label "foid bearing alkali feldspar syenite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Alkali feldspar syenitic rock that contains 0-10 percent feldspathoid mineral and no quartz in the QAPF fraction. QAPF field 6'."@en ;
+    rdfs:subClassOf gsrm:Alkali_Feldspar_Syenitic_Rock .
+
+gsrm:Foid_Bearing_Alkali_Feldspar_Trachyte a owl:Class ;
+    rdfs:label "foid bearing alkali feldspar trachyte"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Alkali feldspar trachytic rock that contains no quartz and between 0 and 10 percent feldspathoid mineral in the QAPF fraction. QAPF field 6'."@en ;
+    rdfs:subClassOf gsrm:Alkali_Feldspar_Trachytic_Rock .
+
+gsrm:Foid_Bearing_Anorthosite a owl:Class ;
+    rdfs:label "foid bearing anorthosite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Anorthositic rock that contains between 0 and 10 percent feldspathoid mineral and no quartz in the QAPF fraction. QAPF field 10'."@en ;
+    rdfs:subClassOf gsrm:Anorthositic_Rock .
+
+gsrm:Foid_Bearing_Diorite a owl:Class ;
+    rdfs:label "foid bearing diorite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Dioritic rock that contains between 0 and 10 percent feldspathoid minerals in the QAPF fraction. QAPF field 10'."@en ;
+    rdfs:subClassOf gsrm:Dioritic_Rock .
+
+gsrm:Foid_Bearing_Gabbro a owl:Class ;
+    rdfs:label "foid bearing gabbro"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Gabbroic rock that contains 0-10 percent feldspathoid minerals and no quartz in the QAPF fraction. QAPF field 10'."@en ;
+    rdfs:subClassOf gsrm:Gabbroic_Rock .
+
+gsrm:Foid_Bearing_Latite a owl:Class ;
+    rdfs:label "foid bearing latite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Latitic rock that contains no quartz and between 0 and 10 percent feldspathoid minerals in the QAPF fraction. QAPF field 8'."@en ;
+    rdfs:subClassOf gsrm:Latitic_Rock .
+
+gsrm:Foid_Bearing_Monzodiorite a owl:Class ;
+    rdfs:label "foid bearing monzodiorite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Monzodioritic rock that contains between 0 and 10 percent feldspathoid mineral."@en ;
+    rdfs:subClassOf gsrm:Monzodioritic_Rock .
+
+gsrm:Foid_Bearing_Monzogabbro a owl:Class ;
+    rdfs:label "foid bearing monzogabbro"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Monzogabbroic rock that contains 0 to 10 percent feldspathoid mineral in the QAPF fraction. QAPF field 9'."@en ;
+    rdfs:subClassOf gsrm:Monzogabbroic_Rock .
+
+gsrm:Foid_Bearing_Monzonite a owl:Class ;
+    rdfs:label "foid bearing monzonite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Monzonitic rock that contains 0-10 percent feldspathoid mineral and no quartz in the QAPF fraction. Includes rocks defined modally in QAPF Field 8'."@en ;
+    rdfs:subClassOf gsrm:Monzonitic_Rock .
+
+gsrm:Foid_Bearing_Syenite a owl:Class ;
+    rdfs:label "foid bearing syenite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Syenitic rock that contains between 0 and 10 percent feldspathoid mineral and no quartz in the QAPF fraction. Defined modally in QAPF Field 7'."@en ;
+    rdfs:subClassOf gsrm:Syenitic_Rock .
+
+gsrm:Foid_Bearing_Trachyte a owl:Class ;
+    rdfs:label "foid bearing trachyte"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Trachytic rock that contains between 0 and 10 percent feldspathoid in the QAPF fraction, and no quartz. QAPF field 7'."@en ;
+    rdfs:subClassOf gsrm:Trachytic_Rock .
+
+gsrm:Foid_Diorite a owl:Class ;
+    rdfs:label "foid diorite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Foid dioritoid in which the plagioclase to total feldspar ratio is greater than 0.9. Includes rocks defined modally in QAPF field 14."@en ;
+    rdfs:subClassOf gsrm:Foid_Dioritoid .
+
+gsrm:Foid_Gabbro a owl:Class ;
+    rdfs:label "foid gabbro"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Foid gabbroid that has a plagioclase to total feldspar ratio greater than 0.9. Includes rocks defined modally in QAPF field 14."@en ;
+    rdfs:subClassOf gsrm:Foid_Gabbroid .
+
+gsrm:Foid_Monzodiorite a owl:Class ;
+    rdfs:label "foid monzodiorite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Foid dioritoid in which the plagioclase to total feldspar ratio is between 0.1 and 0.9. Includes rocks defined modally in QAPF field 13."@en ;
+    rdfs:subClassOf gsrm:Foid_Dioritoid .
+
+gsrm:Foid_Monzogabbro a owl:Class ;
+    rdfs:label "foid monzogabbro"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Foid gabbroid that has a plagioclase to total feldspar ratio between 0.5 and 0.9. Includes rocks defined modally in QAPF field 13."@en ;
+    rdfs:subClassOf gsrm:Foid_Gabbroid .
+
+gsrm:Foid_Monzosyenite a owl:Class ;
+    rdfs:label "foid monzosyenite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Foid syenitoid rock that has a plagioclase to total feldspar ratio of between 0.1 and 0.5. Includes rocks defined modally in QAPF Field 12."@en ;
+    rdfs:subClassOf gsrm:Foid_Syenitoid .
+
+gsrm:Foid_Syenite a owl:Class ;
+    rdfs:label "foid syenite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Foid syenitoid that has a plagioclase to total feldspar ratio of less than 0.1. Includes rocks defined modally in QAPF field 11."@en ;
+    rdfs:subClassOf gsrm:Foid_Syenitoid .
+
+gsrm:Foidite a owl:Class ;
+    rdfs:label "foidite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Foiditoid that contains greater than 90 percent feldspathoid minerals in the QAPF fraction."@en ;
+    rdfs:subClassOf gsrm:Foiditoid ;
+    gsmin:mindatid "min-48512" ;
+    gsmin:mindaturl "https://mindat.org/min-48512.html" .
+
+gsrm:Foidolite a owl:Class ;
+    rdfs:label "foidolite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline rock containing more than 60 percent feldspathoid minerals in the QAPF fraction. Includes rocks defined modally in QAPF field 15"@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
+    gsmin:mindatid "min-48384" ;
+    gsmin:mindaturl "https://mindat.org/min-48384.html" .
+
+gsrm:Framestone a owl:Class ;
+    rdfs:label "framestone"@en ;
+    dct:source "Hallsworth and Knox 1999; SLTTs 2004, Table 15-3-1"@en ;
+    rdfs:comment "Carbonate reef rock consisting of a rigid framework of colonies, shells or skeletons, with internal cavities filled with fine sediment; usually created through the activities of colonial organisms."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
+    gsmin:mindatid "min-50848" ;
+    gsmin:mindaturl "https://mindat.org/min-50848.html" .
+
+gsrm:Gabbro a owl:Class ;
+    rdfs:label "gabbro"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Gabbroic rock that contains between 0 and 5 percent quartz and no feldspathoid mineral in the QAPF fraction. Includes rocks defined modally in QAPF Field 10 as gabbro."@en,
+        "Note that this category includes gabbro (sensu stricto) of LeMaitre et al. 2002, but is broader, including the other rock types defined by orthopyroxene-clinopyroxene-olivine-hornblende mineral ratios."@en ;
+    rdfs:subClassOf gsrm:Gabbroic_Rock ;
+    gsmin:mindatid "min-48275" ;
+    gsmin:mindaturl "https://mindat.org/min-48275.html" .
+
+gsrm:Glassy_Igneous_Rock a owl:Class ;
+    rdfs:label "glassy igneous rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Igneous rock that consists of greater than 80 percent massive glass."@en,
+        "Note that this category is used for massive glassy rocks. Much of the pyroclastic material in a pyroclastic rock may be composed of glass, but the rock is named based on its fragmental nature."@en ;
+    rdfs:subClassOf gsrm:Glass_Rich_Igneous_Rock ;
+    gsmin:mindatid "min-50714" ;
+    gsmin:mindaturl "https://mindat.org/min-50714.html" .
+
+gsrm:Glaucophane_Lawsonite_Epidote_Metamorphic_Rock a owl:Class ;
+    rdfs:label "glaukophanschiefer"@de,
+        "glaucophane lawsonite epidote metamorphic rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "A metamorphic rock of roughly basaltic composition, defined by the presence of glaucophane with lawsonite or epidote. Other minerals that may be present include jadeite, albite, chlorite, garnet, and muscovite (phengitic white mica). Typically fine-grained, dark colored. Category for rocks commonly referred to as blueschist."@en,
+        "Fabric is weakly developed in this rock in many cases, so the fabric categories 'foliated metamorphic rock, 'schist' or 'granofels' may apply."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    skos:altLabel "blauschiefer"@de .
+
+gsrm:Grainstone a owl:Class ;
+    rdfs:label "grainstone"@en ;
+    dct:source "Dunham 1962"@en ;
+    rdfs:comment "Carbonate sedimentary rock with recognizable depositional fabric that is grain-supported, and constituent particles are of intrabasinal origin; contains little or no mud matrix. Distinction from sandstone is based on interpretation of intrabasinal origin of clasts and grain-supported fabric, but grainstone definition does not include a grain size criteria."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
+    skos:altLabel "carbonate grainstone"@en ;
+    gsmin:mindatid "min-50884" ;
+    gsmin:mindaturl "https://mindat.org/min-50884.html" .
+
+gsrm:Granodiorite a owl:Class ;
+    rdfs:label "granodiorite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline rock consisting essentially of quartz, sodic plagioclase and lesser amounts of alkali feldspar with minor hornblende and biotite. Includes rocks defined modally in QAPF field 4."@en ;
+    rdfs:subClassOf gsrm:Granitoid ;
+    gsmin:mindatid "min-48163" ;
+    gsmin:mindaturl "https://mindat.org/min-48163.html" .
+
+gsrm:Granulite a owl:Class ;
+    rdfs:label "granulite"@en ;
+    dct:source "Fettes and Desmons (2007). See also Wimmenauer (1985), Winkler (1979) (D.R. Bowes (1989), The Encyclopedia of Igneous and Metamorphic Petrology; Van Nostrand Reinhold ISBN: 0-442-20623-2 ; wikipedia, http://en.wikipedia.org/wiki/Granulite accessed 5/30/09"@en ;
+    rdfs:comment "Metamorphic rock of high metamorphic grade in which Fe-Mg silicate minerals are dominantly hydroxl-free; feldspar must be present, and muscovite is absent; rock contains less than 90 percent mafic minerals, less than 75 percent calcite and/or dolomite, less than 75 percent quartz, less than 50 percent iron-bearing minerals (hematite, magnetite, limonite-group, siderite, iron-sulfides), and less than 50 percent calc-silicate minerals."@en,
+        "Wimmenauer (1985) requires granulite to consist of at least 20 percent feldspar. Garnet is frequently present; some hornblende or biotite may be present. The rock has a granoblastic texture and gneissose to massive structure; grain size and fabric may be variable on a decimetric scale. Foliation is less well developed than in rock that would typically be called gneiss. The minerals present in a granulite vary depending on the protolith and the temperature and pressure conditions experienced during metamorphism. According to Fettes and Desmons (2007) the main calc-silicate minerals are calcic garnet, calcic plagioclase, calcic scapolite, diopside-hedenbergite, epidote group minerals, hydrogrossular, johannsenite, prehnite, pumpellyite, titanite, vesuvianite, wollastonite. Note that the shale and siltstone categories may apply to any of the mineralogically defined mudstone categories."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-50015" ;
+    gsmin:mindaturl "https://mindat.org/min-50015.html" .
+
+gsrm:Gravel a owl:Class ;
+    rdfs:label "gravel"@en ;
+    dct:source "definition of gravel from SLTTs 2004; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
+    rdfs:comment "Clastic sediment containing greater than 30 percent gravel-size particles (greater than 2.0 mm diameter). Gravel in which more than half of the particles are of epiclastic origin"@en ;
+    rdfs:subClassOf gsrm:Clastic_Sediment,
+        gsrm:Gravel_Size_Sediment ;
+    gsmin:mindatid "min-49404" ;
+    gsmin:mindaturl "https://mindat.org/min-49404.html" .
+
+gsrm:Hornblendite a owl:Class ;
+    rdfs:label "hornblendite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Ultramafic rock that consists of greater than 40 percent hornblende plus pyroxene and has a hornblende to pyroxene ratio greater than 1. Includes olivine hornblendite, olivine-pyroxene hornblendite, pyroxene hornblendite, and hornblendite."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock,
+        gsrm:Ultramafic_Igneous_Rock ;
+    gsmin:mindatid "min-48402" ;
+    gsmin:mindaturl "https://mindat.org/min-48402.html" .
+
+gsrm:Hornfels a owl:Class ;
+    rdfs:label "hornfels"@en ;
+    dct:source "IUGS SCMR 2007 (http://www.bgs.ac.uk/SCMR/)"@en ;
+    rdfs:comment "Granofels formed by contact metamorphism, composed of a mosaic of equidimensional grains in a characteristically granoblastic or decussate matrix; porphyroblasts or relict phenocrysts may be present. Typically fine grained."@en ;
+    rdfs:subClassOf gsrm:Granofels ;
+    gsmin:mindatid "min-48635" ;
+    gsmin:mindaturl "https://mindat.org/min-48635.html" .
+
+gsrm:Hybrid_Sediment a owl:Class ;
+    rdfs:label "hybrid sediment"@en ;
+    dct:source "Hallsworth and Knox, 1999"@en ;
+    rdfs:comment "Sediment that does not fit any of the other sediment composition/genesis categories. Sediment consisting of three or more components which form more than 5 percent but less than 50 precent of the material."@en ;
+    rdfs:subClassOf gsrm:Sediment .
+
+gsrm:Hybrid_Sedimentary_Rock a owl:Class ;
+    rdfs:label "hybrid sedimentary rock"@en ;
+    dct:source "Hallsworth and Knox, 1999"@en ;
+    rdfs:comment "Sedimentary rock that does not fit any of the other composition/genesis categories. Sedimentary rock consisting of three or more components which form more than 5 percent but less than 50 precent of the material."@en ;
+    rdfs:subClassOf gsrm:Sedimentary_Rock .
+
+gsrm:Hydrothermal_Massive_Sulphide a owl:Class ;
+    rdfs:label "Hydrothermal Massive Sulphide"@en ;
+    dct:source "provisional by SMR 2020-06-07"@en ;
+    rdfs:comment "Rock consisting of greater that 50% sulphide or sulfosalt minerals formed by hydrothermal mineralization processes {@en}." ;
+    rdfs:subClassOf gsrm:Massive_Sulphide,
+        gsrm:Metasomatic_Rock ;
+    skos:altLabel "Hydrothermal Massive Sulfide"@en .
+
+gsrm:Hypabyssal_Intrusive_Rock a owl:Class ;
+    rdfs:label "hypabyssal intrusive rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Igneous rocks formed by crystallisation close to the Earth's surface, characterized by more rapid cooling than plutonic setting to produce generally fine-grained intrusive igneous rock, commonly associated with co-magmatic volcanic rocks."@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock .
+
+gsrm:Impure_Calcareous_Carbonate_Sediment a owl:Class ;
+    rdfs:label "impure calcareous carbonate sediment"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Carbonate sediment in which between 50 and 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin, and a calcite (plus aragonite) to dolomite ratio greater than 1 to 1."@en ;
+    rdfs:subClassOf gsrm:Calcareous_Carbonate_Sediment,
+        gsrm:Impure_Carbonate_Sediment ;
+    skos:altLabel "calcareous marl"@en .
+
+gsrm:Impure_Dolomitic_Sediment a owl:Class ;
+    rdfs:label "impure dolomitic sediment"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Carbonate sediment in which between 50 and 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin, and the ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1."@en ;
+    rdfs:subClassOf gsrm:Dolomitic_Sediment,
+        gsrm:Impure_Carbonate_Sediment ;
+    skos:altLabel "dolomitic marl"@en .
+
+gsrm:Impure_Dolostone a owl:Class ;
+    rdfs:label "impure dolomite"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Impure carbonate sedimentary rock with a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1."@en ;
+    rdfs:subClassOf gsrm:Dolomitic_Or_Magnesian_Sedimentary_Rock,
+        gsrm:Impure_Carbonate_Sedimentary_Rock ;
+    skos:altLabel "dolomitic marlstone"@en,
+        "impure dolomitic or magnesian carbonate sedimentary rock"@en,
+        "impure dolostone"@en .
+
+gsrm:Impure_Limestone a owl:Class ;
+    rdfs:label "impure limestone"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Impure carbonate sedimentary rock with a calcite (plus aragonite) to dolomite ratio greater than 1 to 1."@en ;
+    rdfs:subClassOf gsrm:Calcareous_Carbonate_Sedimentary_Rock,
+        gsrm:Impure_Carbonate_Sedimentary_Rock ;
+    skos:altLabel "calcareous marlstone"@en .
+
+gsrm:Iron_Rich_Sediment a owl:Class ;
+    rdfs:label "iron rich sediment"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sediment that consists of at least 50 percent iron-bearing minerals (hematite, magnetite, limonite-group, siderite, iron-sulfides), as determined by hand-lens or petrographic analysis. Corresponds to a rock typically containing 15 percent iron by weight."@en ;
+    rdfs:subClassOf gsrm:Iron_Rich_Sedimentary_Material,
+        gsrm:Sediment .
+
+gsrm:Iron_Rich_Sedimentary_Rock a owl:Class ;
+    rdfs:label "iron rich sedimentary rock"@en ;
+    dct:source "Hallsworth and Knox 1999; SLTTs 2004"@en ;
+    rdfs:comment "Sedimentary rock that consists of at least 50 percent iron-bearing minerals (hematite, magnetite, limonite-group, siderite, iron-sulfides), as determined by hand-lens or petrographic analysis. Corresponds to a rock typically containing 15 percent iron by weight."@en ;
+    rdfs:subClassOf gsrm:Iron_Rich_Sedimentary_Material,
+        gsrm:Sedimentary_Rock .
+
+gsrm:Kalsilitic_And_Melilitic_Rock a owl:Class ;
+    rdfs:label "kalsilitic and melilitic rocks"@en ;
+    dct:source "based on LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous rock containing greater than 10 percent melilite or kalsilite. Typically undersaturated, ultrapotassic (kalsilitic rocks) or calcium-rich (melilitic rocks) mafic or ultramafic rocks."@en ;
+    rdfs:subClassOf gsrm:Exotic_Composition_Igneous_Rock .
+
+gsrm:Komatiitic_Rock a owl:Class ;
+    rdfs:label "komatiitic rock"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Ultramafic, magnesium-rich volcanic rock, typically with spinifex texture of intergrown skeletal and bladed olivine and pyroxene crystals set in abundant glass. Includes komatiite and meimechite."@en ;
+    rdfs:subClassOf gsrm:High_Magnesium_Fine_Grained_Igneous_Rock,
+        gsrm:Ultramafic_Igneous_Rock ;
+    gsmin:mindatid "min-48568" ;
+    gsmin:mindaturl "https://mindat.org/min-48568.html" .
+
+gsrm:Latite a owl:Class ;
+    rdfs:label "latite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Latitic rock that contains between 0 and 5 percent quartz and no feldspathoid in the QAPF fraction. QAPF field 8."@en ;
+    rdfs:subClassOf gsrm:Latitic_Rock ;
+    gsmin:mindatid "min-48473" ;
+    gsmin:mindaturl "https://mindat.org/min-48473.html" .
+
+gsrm:Lignite a owl:Class ;
+    rdfs:label "lignite"@en ;
+    dct:source "Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp."@en ;
+    rdfs:comment "Coal that has a gross calorific value less than 24 MJ/kg (determined in conformance with ISO 1928), and vitrinite mean random reflectance less than 0.6% (determined in conformance with ISO 7404-5). Gross calorific value is recalculated to a moist, ash free basis using bed moisture (determined according to ISO 1015 or ISO 5068). Includes all low-rank coals, including sub-bitiminous coal. A consolidated, dull, soft brown to black coal having many readily discernible plant fragments set in a finer grained organic matrix. Tends to crack and fall apart on drying. Operationally sub-bituminous and bitiminous coal are qualitatively distinguished based on brown streak for sub-bitiminous coal and black streak for bituminous coal."@en ;
+    rdfs:subClassOf gsrm:Coal ;
+    skos:altLabel "low rank coal"@en ;
+    gsmin:mindatid "min-9354" ;
+    gsmin:mindaturl "https://mindat.org/min-9354.html" .
+
+gsrm:Marble a owl:Class ;
+    rdfs:label "marble"@en ;
+    dct:source "IUGS SCMR 2007 (http://www.bgs.ac.uk/SCMR/), SLTTm1.0 2004"@en ;
+    rdfs:comment "Metamorphic rock consisting of greater than 75 percent fine- to coarse-grained recrystallized calcite and/or dolomite; usually with a granoblastic, saccharoidal texture."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-9507" ;
+    gsmin:mindaturl "https://mindat.org/min-9507.html" .
+
+gsrm:Metaplutonic_Rock a owl:Class ;
+    rdfs:label "metaplutonic rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Rock formed by metamorphism of a plutonic igneous protolith."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-51451" ;
+    gsmin:mindaturl "https://mindat.org/min-51451.html" .
+
+gsrm:Metasedimentary_Rock a owl:Class ;
+    rdfs:label "metasedimentary rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Rock formed by metamorphism of a sedimentary protolith."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-48820" ;
+    gsmin:mindaturl "https://mindat.org/min-48820.html" .
+
+gsrm:Metavolcanic_Rock a owl:Class ;
+    rdfs:label "metavolcanic rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Rock formed by metamorphism of an extrusive igneous protolith."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-51450" ;
+    gsmin:mindaturl "https://mindat.org/min-51450.html" .
+
+gsrm:Mica_Schist a owl:Class ;
+    rdfs:label "mica schist"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "A schist that consists of more than 50 percent mica minerals, typically muscovite or biotite. Special type included to distinguish this common variety of schist."@en,
+        "Include single subcategory of schist to indicate this common kind of schist. 'Mica rich metamorphic rock' for compound use with schist fabric term would be more compatible with treatment of blueschist (Glaucophane lawsonite epidote metamorphic rock) and greenschist (Chlorite actinolite epidote metamorphic rock), but based on the assumption that schist is the only rock type that will meet the mica-rich criteria, it seems reasonable to include as a subtype of schist."@en ;
+    rdfs:subClassOf gsrm:Schist ;
+    gsmin:mindatid "min-48645" ;
+    gsmin:mindaturl "https://mindat.org/min-48645.html" .
+
+gsrm:Migmatite a owl:Class ;
+    rdfs:label "migmatite"@en ;
+    dct:source "Fette and Desmons (2007) (http://www.bgs.ac.uk/SCMR/)"@en ;
+    rdfs:comment "Silicate metamorphic rock that is pervasively heterogeneous on a decimeter to meter scale that typically consists of darker and lighter parts; the darker parts usually exhibit features of metamorphic rocks whereas the lighter parts are of igneous-looking appearance."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-50045" ;
+    gsmin:mindaturl "https://mindat.org/min-50045.html" .
+
+gsrm:Monzodiorite a owl:Class ;
+    rdfs:label "monzodiorite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline igneous rock consisting of sodic plagioclase (An0 to An50), alkali feldspar, hornblende and biotite, with or without pyroxene, and 0 to 5 percent quartz. Includes rocks defined modally in QAPF field 9."@en ;
+    rdfs:subClassOf gsrm:Monzodioritic_Rock ;
+    gsmin:mindatid "min-48244" ;
+    gsmin:mindaturl "https://mindat.org/min-48244.html" .
+
+gsrm:Monzogabbro a owl:Class ;
+    rdfs:label "monzogabbro"@en ;
+    dct:source "LeMaitre et al. 2002, This vocabulary"@en ;
+    rdfs:comment "Monzogabbroic rock that contains between 0 an 5 percent quartz and no feldspathoid mineral in the QAPF fraction. Includes rocks defined modally in QAPF field 9 ."@en ;
+    rdfs:subClassOf gsrm:Monzogabbroic_Rock ;
+    gsmin:mindatid "min-48305" ;
+    gsmin:mindaturl "https://mindat.org/min-48305.html" .
+
+gsrm:Monzogranite a owl:Class ;
+    rdfs:label "monzogranite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Granite that has a plagiolcase to total feldspar ratio between 0.35 and 0.65. QAPF field 3b."@en ;
+    rdfs:subClassOf gsrm:Granite ;
+    gsmin:mindatid "min-48160" ;
+    gsmin:mindaturl "https://mindat.org/min-48160.html" .
+
+gsrm:Monzonite a owl:Class ;
+    rdfs:label "monzonite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Monzonitic rock that contains 0-5 percent quartz and no feldspathoid mineral in the QAPF fraction. Includes rocks defined modally in QAPF Field 8."@en ;
+    rdfs:subClassOf gsrm:Monzonitic_Rock ;
+    gsmin:mindatid "min-48196" ;
+    gsmin:mindaturl "https://mindat.org/min-48196.html" .
+
+gsrm:Non_Clastic_Siliceous_Sediment a owl:Class ;
+    rdfs:label "non clastic siliceous sediment"@en ;
+    dct:source "NGMDB 2008; Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Sediment that consists of at least 50 percent silicate mineral material, deposited directly by chemical or biological processes at the depositional surface, or in particles formed by chemical or biological processes within the basin of deposition."@en ;
+    rdfs:subClassOf gsrm:Non_Clastic_Siliceous_Sedimentary_Material,
+        gsrm:Sediment .
+
+gsrm:Organic_Bearing_Mudstone a owl:Class ;
+    rdfs:label "organic bearing mudstone"@en ;
+    dct:source "Neuendorf et al. 2005; http://en.wikipedia.org/wiki/Oil_shale"@en ;
+    rdfs:comment "Mudstone that contains a significant amount of organic carbon, typically kerogen. commonly finely laminated, brown or black in color."@en ;
+    rdfs:subClassOf gsrm:Generic_Mudstone ;
+    skos:altLabel "oil shale"@en .
+
+gsrm:Orthogneiss a owl:Class ;
+    rdfs:label "orthogneiss"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "A gneiss with mineralogy and texture indicating derivation from a phaneritic igneous rock protolith. Typically consists of abundant feldspar, with quartz, and variable hornblende, biotite, and muscovite, with a relatively homogeneous character."@en ;
+    rdfs:subClassOf gsrm:Gneiss ;
+    gsmin:mindatid "min-48818" ;
+    gsmin:mindaturl "https://mindat.org/min-48818.html" .
+
+gsrm:Packstone a owl:Class ;
+    rdfs:label "packstone"@en ;
+    dct:source "Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Carbonate sedimentary rock with discernible grain supported depositional texture, containing greater than 10 percent grains, and constituent particles are of intrabasinal origin; intergranular spaces are filled by matrix."@en,
+        "Note that this category overlaps with 'carbonate mudstone'."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
+    gsmin:mindatid "min-50886" ;
+    gsmin:mindaturl "https://mindat.org/min-50886.html" .
+
+gsrm:Paragneiss a owl:Class ;
+    rdfs:label "paragneiss"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "A gneiss with mineralogy and texture indicating derivation from a sedimentary rock protolith. Typically consists of abundant quartz, mica, or calcsilicate minerals; aluminosilicate minerals or garnet commonly present. composition of rock tends to be more variable on a decimetric scale that in orthogneiss."@en ;
+    rdfs:subClassOf gsrm:Gneiss ;
+    gsmin:mindatid "min-49072" ;
+    gsmin:mindaturl "https://mindat.org/min-49072.html" .
+
+gsrm:Peat a owl:Class ;
+    rdfs:label "peat"@en ;
+    dct:source "Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Unconsolidated organic-rich sediment composed of at least 50 percent semi-carbonised plant remains; individual remains commonly seen with unaided eye; yellowish brown to brownish black; generally fibrous texture; can be plastic or friable. In its natural state it can be readily cut and has a very high moisture content, generally greater than 90 percent. Liptinite to Inertinite ratio is less than one (Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp.)"@en ;
+    rdfs:subClassOf gsrm:Organic_Rich_Sediment ;
+    gsmin:mindatid "min-49302" ;
+    gsmin:mindaturl "https://mindat.org/min-49302.html" .
+
+gsrm:Pebble_Gravel_Size_Sediment a owl:Class ;
+    rdfs:label "pebble gravel size sediment"@en ;
+    dct:source "Wentworth size scale"@en ;
+    rdfs:comment "Sediment containing greater than 30 percent pebble-size particles (2.0 -64 mm in diameter)"@en ;
+    rdfs:subClassOf gsrm:Gravel_Size_Sediment .
+
+gsrm:Pegmatite a owl:Class ;
+    rdfs:label "pegmatite"@en ;
+    dct:source "Neuendorf et al. 2005"@en ;
+    rdfs:comment "Exceptionally coarse grained crystalline rock with interlocking crystals; most grains are 1cm or more diameter; composition is generally that of granite, but the term may refer to the coarse grained facies of any type of igneous rock;usually found as irregular dikes, lenses, or veins associated with plutons or batholiths."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
+    gsmin:mindatid "min-50315" ;
+    gsmin:mindaturl "https://mindat.org/min-50315.html" .
+
+gsrm:Peridotite a owl:Class ;
+    rdfs:label "peridotite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Ultramafic rock consisting of more than 40 percent (by volume) olivine with pyroxene and/or amphibole and little or no feldspar. commonly altered to serpentinite. Includes rocks defined modally in the ultramafic rock classification as dunite, harzburgite, lherzolite, wehrlite, olivinite, pyroxene peridotite, pyroxene hornblende peridotite or hornblende peridotite."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock,
+        gsrm:Ultramafic_Igneous_Rock ;
+    gsmin:mindatid "min-48407" ;
+    gsmin:mindaturl "https://mindat.org/min-48407.html" .
+
+gsrm:Phonolilte a owl:Class ;
+    rdfs:label "phonolite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phonolitoid in which the plagioclase to total feldspar ratio is less than 0.1. Rock consists of alkali feldspar, feldspathoid minerals, and mafic minerals."@en ;
+    rdfs:subClassOf gsrm:Phonolitoid ;
+    gsmin:mindatid "min-48540" ;
+    gsmin:mindaturl "https://mindat.org/min-48540.html" .
+
+gsrm:Phonolitic_Basanite a owl:Class ;
+    rdfs:label "phonolitic basanite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Tephritoid that has a plagioclase to total feldspar ratio between 0.5 and 0.9, and contains more than 10 percent normative (CIPW) olivine."@en ;
+    rdfs:subClassOf gsrm:Tephritoid .
+
+gsrm:Phonolitic_Foidite a owl:Class ;
+    rdfs:label "phonolitic foidite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Foiditoid that contains less than 90 percent feldspathoid minerals in the QAPF fraction, and has a plagioclase to total feldspar ratio that is less than 0.5"@en ;
+    rdfs:subClassOf gsrm:Foiditoid .
+
+gsrm:Phonolitic_Tephrite a owl:Class ;
+    rdfs:label "phonolitic tephrite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Tephritoid that has a plagioclase to total feldspar ratio between 0.5 and 0.9, and contains less than 10 percent normative (CIPW) olivine."@en ;
+    rdfs:subClassOf gsrm:Tephritoid ;
+    gsmin:mindatid "min-54598" ;
+    gsmin:mindaturl "https://mindat.org/min-54598.html" .
+
+gsrm:Phosphate_Rich_Sediment a owl:Class ;
+    rdfs:label "phosphate rich sediment"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sediment in which at least 50 percent of the primary and/or recrystallized constituents are phosphate minerals."@en ;
+    rdfs:subClassOf gsrm:Phosphate_Rich_Sedimentary_Material,
+        gsrm:Sediment .
+
+gsrm:Phosphorite a owl:Class ;
+    rdfs:label "phosphorite"@en ;
+    dct:source "HallsworthandKnox 1999, Jackson 1997"@en ;
+    rdfs:comment "Sedimentary rock in which at least 50 percent of the primary or recrystallized constituents are phosphate minerals. Most commonly occurs as a bedded primary or reworked secondary marine rock, composed of microcrystalline carbonate fluorapatite in the form of lamina, pellets, oolites and nodules, and skeletal, shell and bone fragments."@en ;
+    rdfs:subClassOf gsrm:Phosphate_Rich_Sedimentary_Material,
+        gsrm:Sedimentary_Rock ;
+    gsmin:mindatid "min-9442" ;
+    gsmin:mindaturl "https://mindat.org/min-9442.html" .
+
+gsrm:Phyllite a owl:Class ;
+    rdfs:label "phyllite"@en ;
+    dct:source "IUGS SCMR 2007 (http://www.bgs.ac.uk/SCMR/)"@en ;
+    rdfs:comment "Rock with a well developed, continuous schistosity, an average grain size between 0.1 and 0.5 millimeters, and a silvery sheen on cleavage surfaces. Individual phyllosilicate grains are barely visible with the unaided eye."@en ;
+    rdfs:subClassOf gsrm:Foliated_Metamorphic_Rock ;
+    gsmin:mindatid "min-50064" ;
+    gsmin:mindaturl "https://mindat.org/min-50064.html" .
+
+gsrm:Phyllonite a owl:Class ;
+    rdfs:label "phyllonite"@en ;
+    dct:source "NADM metamorphic rock vocabulary SLTTm1.0; Marshak and Mitra 1988"@en ;
+    rdfs:comment "Mylonitic rock composed largely of fine-grained mica that imparts a sheen to foliation surfaces; may have flaser lamination, isoclinal folding, and deformed veins, which indicate significant shearing. Macroscopically resembles phyllite, but formed by mechanical degradation of initially coarser rock."@en ;
+    rdfs:subClassOf gsrm:Mylonitic_Rock ;
+    gsmin:mindatid "min-48669" ;
+    gsmin:mindaturl "https://mindat.org/min-48669.html" .
+
+gsrm:Plutonic_Igneous_Rock a owl:Class ;
+    rdfs:label "plutonic rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Instrusive igneous rock formed by crystallisation of magma far enough below Earth surface that complete crystallization of magma bodies forms holocrystalline medium to coarse grained igneous rock, wall rocks generally do not include volcanic products related to the magma, and some contact metamorphism is tyypically developed at intrusive contacts."@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock .
+
+gsrm:Porphyry a owl:Class ;
+    rdfs:label "porphyry"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous rock that contains conspicuous phenocrysts in a finer grained groundmass; groundmass itself may be phaneritic or fine-grained."@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock ;
+    gsmin:mindatid "min-48434" ;
+    gsmin:mindaturl "https://mindat.org/min-48434.html" .
+
+gsrm:Pure_Calcareous_Carbonate_Sediment a owl:Class ;
+    rdfs:label "pure calcareous carbonate sediment"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Carbonate sediment in which greater than 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin, and a calcite (plus aragonite) to dolomite ratio greater than 1 to 1."@en ;
+    rdfs:subClassOf gsrm:Calcareous_Carbonate_Sediment,
+        gsrm:Pure_Carbonate_Sediment ;
+    skos:altLabel "lime sediment"@en .
+
+gsrm:Pure_Carbonate_Mudstone a owl:Class ;
+    rdfs:label "pure carbonate mudstone"@en ;
+    dct:source "Dunham 1962"@en ;
+    rdfs:comment "Mudstone that consists of greater than 90 percent carbonate minerals of intrabasinal orign in the mud fraction, and contains less than 10 percent allochems. The original depositional texture is preserved and fabric is matrix supported. Carbonate mudstone of Dunham (1962)"@en ;
+    rdfs:subClassOf gsrm:Generic_Mudstone,
+        gsrm:Pure_Carbonate_Sedimentary_Rock .
+
+gsrm:Pure_Dolomitic_Sediment a owl:Class ;
+    rdfs:label "pure dolomitic sediment"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Carbonate sediment in which greater than 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin, and a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1."@en ;
+    rdfs:subClassOf gsrm:Dolomitic_Sediment,
+        gsrm:Pure_Carbonate_Sediment .
+
+gsrm:Pyroxenite a owl:Class ;
+    rdfs:label "pyroxenite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Ultramafic phaneritic igneous rock composed almost entirely of one or more pyroxenes and occasionally biotite, hornblende and olivine. Includes rocks defined modally in the ultramafic rock classification as olivine pyroxenite, olivine-hornblende pyroxenite, pyroxenite, orthopyroxenite, clinopyroxenite and websterite."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock,
+        gsrm:Ultramafic_Igneous_Rock ;
+    gsmin:mindatid "min-48417" ;
+    gsmin:mindaturl "https://mindat.org/min-48417.html" .
+
+gsrm:Quartz_Alkali_Feldspar_Syenite a owl:Class ;
+    rdfs:label "quartz alkali feldspar syenite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Alkali feldspar syenitic rock that contains 5 to 20 percent quartz and no feldspathoid in the QAPF fraction. QAPF field 6*."@en ;
+    rdfs:subClassOf gsrm:Alkali_Feldspar_Syenitic_Rock .
+
+gsrm:Quartz_Alkali_Feldspar_Trachyte a owl:Class ;
+    rdfs:label "quartz alkali feldspar trachyte"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Alkali feldspar trachytic rock that contains and between 5 and 20 percent quartz mineral in the QAPF fraction. QAPF field 6*."@en ;
+    rdfs:subClassOf gsrm:Alkali_Feldspar_Trachytic_Rock .
+
+gsrm:Quartz_Anorthosite a owl:Class ;
+    rdfs:label "quartz anorthosite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Anorthositic rock that contains between 5 and 20 percent quartz in the QAPF fraction. QAPF field 10*."@en ;
+    rdfs:subClassOf gsrm:Anorthositic_Rock .
+
+gsrm:Quartz_Diorite a owl:Class ;
+    rdfs:label "quartz diorite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Dioritic rock that contains between 5 to 20 percent quartz in the QAPF fraction. QAPF field 10*."@en ;
+    rdfs:subClassOf gsrm:Dioritic_Rock .
+
+gsrm:Quartz_Gabbro a owl:Class ;
+    rdfs:label "quartz gabbro"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Gabbroic rock that contains between 5 and 20 percent quartz in the QAPF fraction. QAPF field 10*."@en ;
+    rdfs:subClassOf gsrm:Gabbroic_Rock ;
+    gsmin:mindatid "min-50544" ;
+    gsmin:mindaturl "https://mindat.org/min-50544.html" .
+
+gsrm:Quartz_Latite a owl:Class ;
+    rdfs:label "quartz latite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Latitic rock that contains between 5 and 20 percent quartz in the QAPF fraction. QAPF field 8*."@en ;
+    rdfs:subClassOf gsrm:Latitic_Rock .
+
+gsrm:Quartz_Monzodiorite a owl:Class ;
+    rdfs:label "quartz monzodiorite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Monzodioritic rock that contains between 5 and 20 percent quartz."@en ;
+    rdfs:subClassOf gsrm:Monzodioritic_Rock .
+
+gsrm:Quartz_Monzogabbro a owl:Class ;
+    rdfs:label "quartz monzogabbro"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Monzogabbroic rock that contains between 5 and 20 percent quartz in the QAPF fraction. QAPF field 9*."@en ;
+    rdfs:subClassOf gsrm:Monzogabbroic_Rock .
+
+gsrm:Quartz_Monzonite a owl:Class ;
+    rdfs:label "quartz monzonite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Monzonitic rock that contains 5-20 percent quartz iin the QAPF fraction. Includes rocks defined modally in QAPF Field 8*."@en ;
+    rdfs:subClassOf gsrm:Monzonitic_Rock .
+
+gsrm:Quartz_Rich_Igneous_Rock a owl:Class ;
+    rdfs:label "quartz rich igneous rock"@en ;
+    dct:source "Gillespie and Styles 1999; LeMaitre et al. 2002"@en ;
+    rdfs:comment "Occurrence of igneous rocks meeting this criteria seems to be vanishingly rare, thus subdividing the category does not seem warranted for the purposes of This vocabulary. Future usage of the vocabulary may motivate including quatzolite and quartz-rich granitoid in future revisions"@en,
+        "Phaneritic crystalline igneous rock that contains less than 90 percent mafic minerals and contains greater than 60 percent quartz in the QAPF fraction."@en ;
+    rdfs:subClassOf gsrm:Acidic_Igneous_Rock,
+        gsrm:Phaneritic_Igneous_Rock .
+
+gsrm:Quartz_Syenite a owl:Class ;
+    rdfs:label "quartz syenite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Syenitic rock that contains between 5 and 20 percent quartz in the QAPF fraction. Defined modally in QAPF Field 7*."@en ;
+    rdfs:subClassOf gsrm:Syenitic_Rock .
+
+gsrm:Quartz_Trachyte a owl:Class ;
+    rdfs:label "quartz trachyte"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Trachytic rock that contains between 5 and 20 percent quartz in the QAPF fraction. QAPF field 7*."@en ;
+    rdfs:subClassOf gsrm:Trachytic_Rock .
+
+gsrm:Quartzite a owl:Class ;
+    rdfs:label "quartzite"@en ;
+    dct:source "after Neuendorf et al. 2005"@en ;
+    rdfs:comment "Metamorphic rock consisting of greater than or equal to 75 percent quartz; typically granoblastic texture."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-51087" ;
+    gsmin:mindaturl "https://mindat.org/min-51087.html" .
+
+gsrm:Rhyolite a owl:Class ;
+    rdfs:label "rhyolite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "rhyolitoid in which the ratio of plagioclase to total feldspar is between 0.1 and 0.65."@en ;
+    rdfs:subClassOf gsrm:Rhyolitoid ;
+    gsmin:mindatid "min-48451" ;
+    gsmin:mindaturl "https://mindat.org/min-48451.html" .
+
+gsrm:Rock_Gypsum_Or_Anhydrite a owl:Class ;
+    rdfs:label "gypsum or anhydrite"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Evaporite composed of at least 50 percent gypsum or anhydrite."@en ;
+    rdfs:subClassOf gsrm:Evaporite .
+
+gsrm:Rock_Salt a owl:Class ;
+    rdfs:label "rock salt"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Evaporite composed of at least 50 percent halite."@en ;
+    rdfs:subClassOf gsrm:Evaporite .
+
+gsrm:Sand a owl:Class ;
+    rdfs:label "sand"@en ;
+    dct:source "definition of sand from SLTTs 2004 sandy sediment; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
+    rdfs:comment "Clastic sediment in which less than 30 percent of particles are gravel (greater than 2 mm in diameter) and the sand to mud ratio is at least 1. More than half of the particles are of epiclastic origin."@en ;
+    rdfs:subClassOf gsrm:Clastic_Sediment,
+        gsrm:Sand_Size_Sediment ;
+    gsmin:mindatid "min-49414" ;
+    gsmin:mindaturl "https://mindat.org/min-49414.html" .
+
+gsrm:Sapropel a owl:Class ;
+    rdfs:label "sapropel"@en ;
+    dct:source "Neuendorf et al. 2005"@en ;
+    rdfs:comment "Jelly like organic rich sediment composed of plant remains, usually algal. Liptinite to Inertinite ratio is greater than one (Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp.)"@en ;
+    rdfs:subClassOf gsrm:Organic_Rich_Sediment ;
+    gsmin:mindatid "min-49305" ;
+    gsmin:mindaturl "https://mindat.org/min-49305.html" .
+
+gsrm:Sedimentary_Massive_Sulphide a owl:Class ;
+    rdfs:label "Sedimentary Massive Sulphide"@en ;
+    dct:source "smr provisional 2020-06-07"@en ;
+    rdfs:comment "rock consisting of greater than 50% sulphide or sulfosalt minerals formed by sedimentary exhalative processes."@en ;
+    rdfs:subClassOf gsrm:Chemical_Sedimentary_Material,
+        gsrm:Massive_Sulphide ;
+    skos:altLabel "Sedimentary Massive Sulfide"@en .
+
+gsrm:Serpentinite a owl:Class ;
+    rdfs:label "serpentinite"@en ;
+    dct:source "Neuendorf et al. 2005"@en ;
+    rdfs:comment "Rock consisting of more than 75 percent serpentine-group minerals, eg. antigorite, chrysotile or lizardite; accessory chlorite, talc and magnetite may be present; derived from hydration of ferromagnesian silicate minerals such as olivine and pyroxene."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-48762" ;
+    gsmin:mindaturl "https://mindat.org/min-48762.html" .
+
+gsrm:Shale a owl:Class ;
+    rdfs:label "shale"@en ;
+    dct:source "NADM SLTT sedimentary, 2004"@en ;
+    rdfs:comment "Laminated mudstone that will part or break along thin, closely spaced layers parallel to stratification."@en,
+        "Note definition does not specify carbonate vs. siliclastic nature of mud."@en ;
+    rdfs:subClassOf gsrm:Clastic_Mudstone ;
+    gsmin:mindatid "min-49444" ;
+    gsmin:mindaturl "https://mindat.org/min-49444.html" .
+
+gsrm:Silicate_Mudstone a owl:Class ;
+    rdfs:label "silicate mudstone"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Mudstone that contains less than 10 percent carbonate minerals."@en,
+        "Operational distinction of this category will typically be based on whether or not the rock fizzes when hydrochloric acid is applied--the rock is silicate mudstone if it does not fizz. The quantitative '10 percent' criteria is fuzzy."@en ;
+    rdfs:subClassOf gsrm:Generic_Mudstone .
+
+gsrm:Siliceous_Ooze a owl:Class ;
+    rdfs:label "siliceous ooze"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "ooze that consists of more than 50 percent siliceous skeletal remains"@en ;
+    rdfs:subClassOf gsrm:Ooze,
+        gsrm:Silicate_Mud .
+
+gsrm:Silt a owl:Class ;
+    rdfs:label "silt"@en ;
+    dct:source "based on SLTTs 2004; Neuendorf et al. 2005; particle size from Wentworth grade scale."@en ;
+    rdfs:comment "Mud that consists of greater than 50 percent silt-size grains. Silt size is between .004 and .063 mm. Note that BGS definition of silt grade is .004 to .032 μm, includes only half if the Wentworth size range. Fortunately, in lithified rocks that have undergone any diagnesis, grain size distinctions in this size range are questionable."@en ;
+    rdfs:subClassOf gsrm:Mud ;
+    skos:altLabel "loess"@en ;
+    gsmin:mindatid "min-49428" ;
+    gsmin:mindaturl "https://mindat.org/min-49428.html" .
+
+gsrm:Siltstone a owl:Class ;
+    rdfs:label "siltstone"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Mudstone that contains detectable silt. (see comments)"@en,
+        "Use of 'dectable silt' in the criteria for this category is based on the observation that in practice, distinction of claystone from 'siltstone' is typically based on a qualitative assessment of 'grittiness' (e.g. rubbing with fingers, or chewing); the property that these tests can determine is the presence or absence of silty particles in the material. Quantitative grain size analysis in the the clay/silt fraction of a lithified sediment is difficult at best, and of questionable significance because diagensis has altered the size and mineralogy of original sedimentary particles."@en ;
+    rdfs:subClassOf gsrm:Clastic_Mudstone ;
+    skos:altLabel "Silt bearing mudstone"@en ;
+    gsmin:mindatid "min-49448" ;
+    gsmin:mindaturl "https://mindat.org/min-49448.html" .
+
+gsrm:Skarn a owl:Class ;
+    rdfs:label "skarn"@en ;
+    dct:source "Fettes and Desmons, 2007, p195"@en ;
+    rdfs:comment "Metasomatic rock consisting mainly of Ca-, Mg-, Fe-, or Mn-silicate minerals, which are free from or poor in water. Typically formed at the contact between a silicate rock or magma and a carbonate rock."@en ;
+    rdfs:subClassOf gsrm:Metasomatic_Rock ;
+    skos:altLabel "exoskarn"@en,
+        "tactite"@en ;
+    gsmin:mindatid "min-48656" ;
+    gsmin:mindaturl "https://mindat.org/min-48656.html" .
+
+gsrm:Slate a owl:Class ;
+    rdfs:label "slate"@en ;
+    dct:source "NADM metamorphic rock vocabulary SLTTm1.0; Neuendorf et al. 2005"@en ;
+    rdfs:comment "compact, fine grained rock with an average grain size less than 0.032 millimeter and a well developed schistosity (slaty cleavage), and hence can be split into slabs or thin plates."@en ;
+    rdfs:subClassOf gsrm:Foliated_Metamorphic_Rock ;
+    gsmin:mindatid "min-48638" ;
+    gsmin:mindaturl "https://mindat.org/min-48638.html" .
+
+gsrm:Spilite a owl:Class ;
+    rdfs:label "spilite"@en ;
+    dct:source "Fettes and Desmon, 2007; Best, M.G., 1982, Igneous and metamorphic petrology: New York, W.H. Freeman and company, p. 398; Neuendorf et al. 2005, p. 619."@en ;
+    rdfs:comment "Altered basic to intermediate composition fine-grained igneous rock in which the feldspar is partially or completely composed of of albite, typically accompanied by chlorite, calcite, quartz, epidote, prehnite, and low-tempaerature hydrous crystallization products. Preservation of eruptive volcanic features is typical."@en ;
+    rdfs:subClassOf gsrm:Metasomatic_Rock ;
+    gsmin:mindatid "min-50065" ;
+    gsmin:mindaturl "https://mindat.org/min-50065.html" .
+
+gsrm:Syenite a owl:Class ;
+    rdfs:label "syenite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Syenitic rock that contains between 0 and 5 percent quartz and no feldspathoid mineral in the QAPF fraction. Defined modally in QAPF Field 7."@en ;
+    rdfs:subClassOf gsrm:Syenitic_Rock ;
+    gsmin:mindatid "min-48213" ;
+    gsmin:mindaturl "https://mindat.org/min-48213.html" .
+
+gsrm:Syenogranite a owl:Class ;
+    rdfs:label "syenogranite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Granite that has a plagiolcase to total feldspar ratio between 0.10 and 0.35. QAPF field 3a."@en ;
+    rdfs:subClassOf gsrm:Granite ;
+    gsmin:mindatid "min-50288" ;
+    gsmin:mindaturl "https://mindat.org/min-50288.html" .
+
+gsrm:Tephrite a owl:Class ;
+    rdfs:label "tephrite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Tephritoid that has a plagioclase to total feldspar ratio greater than 0.9, and contains less than 10 percent normative (CIPW) olivine."@en ;
+    rdfs:subClassOf gsrm:Tephritoid ;
+    gsmin:mindatid "min-48563" ;
+    gsmin:mindaturl "https://mindat.org/min-48563.html" .
+
+gsrm:Tephritic_Foidite a owl:Class ;
+    rdfs:label "tephritic foidite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Foiditoid that contains less than 90 percent feldspathoid minerals in the QAPF fraction, and has a plagioclase to total feldspar ratio that is greater than 0.5, with less than 10 percent normative olivine"@en ;
+    rdfs:subClassOf gsrm:Foiditoid .
+
+gsrm:Tephritic_Phonolite a owl:Class ;
+    rdfs:label "tephritic phonolite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phonolitoid that has a plagioclase to total feldspar ratio between 0.1 and 0.5. Broadly corresponds to TAS tephriphonolite of TAS field U3."@en ;
+    rdfs:subClassOf gsrm:Phonolitoid ;
+    gsmin:mindatid "min-54597" ;
+    gsmin:mindaturl "https://mindat.org/min-54597.html" .
+
+gsrm:Tholeiitic_Basalt a owl:Class ;
+    rdfs:label "tholeiitic basalt"@en ;
+    dct:source "http://en.wikipedia.org/wiki/Basalt; Carmichael, I.S. Turner, F.J., Verhoogen, John, 1974, Igneous petrology: New York, McGraw HIll Book Co., p.42-43."@en ;
+    rdfs:comment "Definition of tholeiite and alkali basalt here are more proscriptive than those found in most reference authorities. This is to actually provide some descriptive criteria to allow assignment of rocks on a hand sample basis to the tholeiite or alkali basalt categories if detailed petrographic or chemical data are available."@en,
+        "Tholeiitic basalt is defined here to contain 2 pyroxene phases and interstitial quartz or tridymite or cristobalite in the groundmass. Pyroxene (augite and orthopyroxene or pigeonite) and calcium-rich plagioclase are common phenocryst minerals. Olivine may also be a phenocryst, and when present, may have rims of pigeonite. Only in tholeiitic basalt is olivine in reaction relationship with melt. Interstitial siliceous residue may be present, and is often glassy. Tholeiitic basalt is relatively poor in sodium. This category includes most basalts of the ocean floor, most large oceanic islands, and continental flood basalts such as the Columbia River Plateau."@en ;
+    rdfs:subClassOf gsrm:Basalt ;
+    gsmin:mindatid "min-48498" ;
+    gsmin:mindaturl "https://mindat.org/min-48498.html" .
+
+gsrm:Tonalite a owl:Class ;
+    rdfs:label "tonalite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Granitoid consisting of quartz and intermediate plagioclase, usually with biotite and amphibole. Includes rocks defined modally in QAPF field 5; ratio of plagioclase to total feldspar is greater than 0.9."@en ;
+    rdfs:subClassOf gsrm:Granitoid ;
+    gsmin:mindatid "min-48173" ;
+    gsmin:mindaturl "https://mindat.org/min-48173.html" .
+
+gsrm:Trachyte a owl:Class ;
+    rdfs:label "trachyte"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Trachytoid that has a plagioclase to total feldspar ratio between 0.1 and 0.35, between 0 and 5 percent quartz in the QAPF fraction, and no feldspathoid minerals. QAPF field 7."@en ;
+    rdfs:subClassOf gsrm:Trachytic_Rock ;
+    gsmin:mindatid "min-48478" ;
+    gsmin:mindaturl "https://mindat.org/min-48478.html" .
+
+gsrm:Travertine a owl:Class ;
+    rdfs:label "travertine"@en ;
+    dct:source "Neuendorf et al. 2005; http://en.wikipedia.org/wiki/Travertine; Chafetz, H.S., and Folk, R.L., 1984, Travertine: Depositional morphology an dthe bacterially constructed constituents: J. Sed. Petrology, v. 126, p.57-74."@en ;
+    rdfs:comment "Biotically or abiotically precipitated calcium carbonate, from spring-fed, heated, or ambient-temperature water. May be white and spongy, various shades of orange, tan or gray, and ranges to dense, banded or laminated rock. Macrophytes, bryophytes, algae, cyanobacteria and other organisms often colonize the surface of travertine and may be preserved, to produce the porous varieties."@en ;
+    rdfs:subClassOf gsrm:Chemical_Sedimentary_Material,
+        gsrm:Limestone ;
+    gsmin:mindatid "min-39057" ;
+    gsmin:mindaturl "https://mindat.org/min-39057.html" .
+
+gsrm:Tuff_Breccia_Agglomerate_Or_Pyroclastic_Breccia a owl:Class ;
+    rdfs:label "tuff breccia agglomerate or pyroclastic breccia"@en ;
+    dct:source "Schmid 1981; LeMaitre et al. 2002"@en ;
+    rdfs:comment "Pyroclastic rock in which greater than 25 percent of particles are greater than 64 mm in largest dimension. Includes agglomerate, pyroclastic breccia of Gillespie and Styles (1999)"@en ;
+    rdfs:subClassOf gsrm:Pyroclastic_Rock .
+
+gsrm:Tuffite a owl:Class ;
+    rdfs:label "tuffit"@de,
+        "tuffite"@en ;
+    dct:source "LeMaitre et al. 2002; Murawski and Meyer 1998"@en ;
+    rdfs:comment "synonym: volcaniclastic rock",
+        "In practice, it is likely that any rock for which there is suspicion that it may consist of redeposited pyroclastic material, usually based on sedimentary structures, irrespective of the presence or percentage of clearly epiclastic particles, would be called a tuffite. 50 percent cutoff with epiclastic rock is in contrast with LeMaitre et al., but is used for consistentency with other sedimentary rock categories following the pattern that the rock name reflects the predominant constituent."@en,
+        "Rock consists of more than 50 percent particles of indeterminate pyroclastic or epiclastic origin and less than 75 percent particles of clearly pyroclastic origin. commonly the rock is laminated or exhibits size grading. (based on LeMaitre et al. 2002; Murawski and Meyer 1998)."@en ;
+    rdfs:subClassOf gsrm:Rock ;
+    gsmin:mindatid "min-49469" ;
+    gsmin:mindaturl "https://mindat.org/min-49469.html" .
+
+gsrm:Ultrabasic_Igneous_Rock a owl:Class ;
+    rdfs:label "ultrabasic igneous rock"@en ;
+    dct:source "after LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous rock with less than 45 percent SiO2."@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock .
+
+gsrm:Wacke a owl:Class ;
+    rdfs:label "wacke"@en,
+        "piedra"@es ;
+    dct:source "Pettijohn, Potter, Siever, 1972, Sand and Sandstone: New York, Springer Verlag, 681 p."@en ;
+    rdfs:comment "Clastic sandstone with more than 10 percent matrix of indeterminate detrital or diagenetic nature. Matrix is mud size silicate minerals (clay, feldspar, quartz, rock fragments, and alteration products)."@en,
+        "Distinction from mudstone is based on inference that less that 50 percent of the mud size fraction (matrix) is original mud size detrital particles. May also grade into diamictite or conglomerate based on size distribution of discernible particles. If more than 50 percent of rock is detrital particles of intrabasinal orgin and carbonate composition, categorize as carbonate wackestone. Term is typically applied to diagenetically altered volcanic-lithic clastic rocks in which the definition of the original clasts has been obscured. Suggested boundaries between wacke and arenite range from 5 to 15 percent matrix. See Dickinson (1970) for discussion of interpretation of undiscernible matrix in diagenetically altered lithic clastic rocks. Dickinson, W.R., 1970, Interpreting detrital modes of graywacke and arkose: Journal of Sedimentary Petrology, v. 40, p. 695-707."@en ;
+    rdfs:subClassOf gsrm:Clastic_Sandstone ;
+    gsmin:mindatid "min-49441" ;
+    gsmin:mindaturl "https://mindat.org/min-49441.html" .
+
+gsrm:advanced_argillic_altered_rock a owl:Class ;
+    rdfs:label "advanced argillic altered rock"@en ;
+    dct:source "Antonio Arribas, Jeffrey Hedenquist, 2019, Environments of advanced argillic alteration: II) steam-heated, and exploration implications: Conference: Society of Resource Geology Annual SymposiumAt: University of Tokyo, Tokyo (Japan)Volume: 69, accessed at https://www.researchgate.net/publication/334230797_Environments_of_advanced_argillic_alteration_II_steam-heated_and_exploration_implications#fullTextFileContent; Constantinos Mavrogonatos et al., 2018, Mineralogical Study of the Advanced Argillic Alteration Zone at the Konos Hill Mo–Cu–Re–Au Porphyry Prospect, NE Greece: Minerals, 8, 479; doi:10.3390/min8110479;  https://en.wikipedia.org/wiki/Argillic_alteration"@en ;
+    rdfs:comment "Advanced argillic alteration occurs under lower pH and higher temperature conditions than argillic alteration. Kaolinite and dickite occur at lower temperatures whereas pyrophyllite and andalusite occur under high temperature conditions (T > 300°C). Quartz deposition is common. Alunite, topaz, zunyite, tourmaline, enargite and tennantite may also occur. In many cases, advanced argillic alteration zones, or “lithocaps”, develop at shallow levels above porphyry Cu–Au deposits (e.g., Lepanto-Far Southeast, Philippines; Maricunga, Chile). Advanced argillic alteration mineral assemblages precipitate from SO2- and HCl-rich magmatic vapor, which arises from an underlying intrusive source, and can also form in supergene environments, due to post-hydrothermal weathering and oxidation of pyrite, locally creating pH<1 liquid due to high concentrations of H2SO4 within the vadose zone, where kaolinite and alunite plus Fe hydroxides form."@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:albitic_altered_rock a owl:Class ;
+    rdfs:label "albitic altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:alunitic_altered_rock a owl:Class ;
+    rdfs:label "alunitic altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:any_consolidation a owl:Class ;
+    rdfs:label "consolidation not specified"@en ;
+    dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "In normative descriptions, indicates that consolidation state is not a determining factor in identification, it may have any value."@en ;
+    rdfs:subClassOf gsrm:Consolidation_Degree_Value .
+
+gsrm:argillic_altered_rock a owl:Class ;
+    rdfs:label "argillic altered rock"@en ;
+    dct:source "https://en.wikipedia.org/wiki/Argillic_alteration"@en ;
+    rdfs:comment "Argillic alteration is hydrothermal alteration of wall rock which introduces clay minerals including kaolinite, smectite and illite. The process generally occurs at low temperatures and may occur in atmospheric conditions. Argillic alteration is representative of supergene environments where low temperature groundwater becomes acidic. Argillic assemblages include kaolinite replacing plagioclase and montmorillonite replacing amphibole and plagioclase. Orthoclase is generally stable and unaffected. Argillic grades into phyllic alteration at higher temperatures in an ore deposit hydrothermal system."@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:bauxite a owl:Class ;
+    rdfs:label "bauxite"@en ;
+    dct:source "Eggleton 2001"@en ;
+    rdfs:comment "Highly aluminous material containing abundant aluminium hydroxides (gibbsite, less commonly boehmite, diaspore) and aluminium-substituted iron oxides or hydroxides and generally minor or negligible kaolin minerals; may contain up to 20 percent quartz. commonly has a pisolitic or nodular texture, and may be cemented."@en ;
+    rdfs:subClassOf gsrm:material_formed_in_surficial_environment ;
+    gsmin:mindatid "min-575" ;
+    gsmin:mindaturl "https://mindat.org/min-575.html" .
+
+gsrm:breccia_gouge_series a owl:Class ;
+    rdfs:label "breccia gouge series"@en ;
+    dct:source "SLTTm 2004"@en ;
+    rdfs:comment "Fault-related material with features such as void spaces (filled or unfilled), or unconsolidated matrix material between fragments, indicating loss of cohesion during deformation. Includes fault-related breccia and gouge."@en ;
+    rdfs:subClassOf gsrm:fault_related_material .
+
+gsrm:calcsilicate_altered_rock a owl:Class ;
+    rdfs:label "calcsilicate altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:carbonate_altered_rock a owl:Class ;
+    rdfs:label "carbonate altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:chloritic_altered_rock a owl:Class ;
+    rdfs:label "chloritic altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:consolidation_variable a owl:Class ;
+    rdfs:label "consolidation variable"@en ;
+    dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "Consolidation ranges from unconsolidated to indurated on scale of description"@en ;
+    rdfs:subClassOf gsrm:Consolidation_Degree_Value .
+
+gsrm:deuteric_altered_rock a owl:Class ;
+    rdfs:label "deuteric altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:epidote_altered_rock a owl:Class ;
+    rdfs:label "epidote altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:greisen a owl:Class ;
+    rdfs:label "greisen"@en ;
+    dct:source "https://en.wikipedia.org/wiki/Greisen"@en ;
+    rdfs:comment "Greisen is a class of endoskarn,  formed by self-generated alteration of a granite. Greisens appear as partly coarse, crystalline granite, partly vuggy with miarolitic cavities, disseminated halide minerals such as fluorite, and occasionally metallic oxide and sulfide ore minerals, borate minerals (tourmaline) and accessory phases such as sphene, beryl or topaz."@en ;
+    rdfs:subClassOf gsrm:altered_rock ;
+    gsmin:mindatid "min-48655" ;
+    gsmin:mindaturl "https://mindat.org/min-48655.html" .
+
+gsrm:hematitic_altered_rock a owl:Class ;
+    rdfs:label "hematitic altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:impact_generated_material a owl:Class ;
+    rdfs:label "impact generated material"@en ;
+    dct:source "Stöffler and Grieve 2007; Jackson 1997"@en ;
+    rdfs:comment "Material that contains features indicative of shock metamorphism, such as microscopic planar deformation features within grains or shatter cones, interpreted to be the result of extraterrestrial bolide impact. Includes breccias and melt rocks."@en ;
+    rdfs:subClassOf gsrm:Composite_Genesis_Material .
+
+gsrm:incipient_consolidation a owl:Class ;
+    rdfs:label "incipient consolidation"@en ;
+    dct:source "NADM sedimentary rock vocabulary NADM sedimentary rock vocabulary (https://pubs.usgs.gov/of/2004/1451/sltt/appendixC/appendixC_pdf.zip)  SLTTs 2004,  after Bowles 1986"@en ;
+    rdfs:comment "Shoveled with difficulty, relative density 0.4 - 0.7."@en ;
+    rdfs:subClassOf gsrm:unconsolidated .
+
+gsrm:kaolinitic_altered_rock a owl:Class ;
+    rdfs:label "kaolinitic altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:moderately_indurated a owl:Class ;
+    rdfs:label "moderately indurated"@en ;
+    dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "Multiple blows with standard rock hammer (less than 1 kg) are required to break rock."@en ;
+    rdfs:subClassOf gsrm:indurated .
+
+gsrm:not_altered_rock a owl:Class ;
+    rdfs:label "material not altered"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "Material without any significant secondary alteration."@en ;
+    rdfs:subClassOf gsrm:Metasomatic_Rock .
+
+gsrm:ontology a owl:Ontology ;
+    rdfs:label "Geoscience Ontology, Rock Types" ;
+    dct:bibliographicCitation "Brodaric, B., and Richard, S.M., 2021, The GeoScience Ontology Reference: Geological Survey of Canada Open File 8796, 34 p., https://doi.org/10.4095/328296" ;
+    dct:created "2021-03-26"^^xsd:date ;
+    dct:creator gsoc:boyan_brodaric,
+        gsoc:stephen_richard ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/legalcode> ;
+    dct:modified "2021-03-26"^^xsd:date ;
+    dct:publisher "ARC Loop3D project;  https://loop3d.org/",
+        "Geological Survey of Canada, Natural Resources Canada, Government of Canada" ;
+    dct:rights "Copyright (c) 2021 Government of Canada" ;
+    dct:source "<http://resource.geosciml.org/classifierScheme/cgi/2016.01/simplelithology>" ;
+    rdfs:comment "Rock type categories modified from CGI SimpleLithology; properties based on GeoSciML v3.2 conceptual model. Scope includes gso Rock_Material and gso Granular Material. GSO granular material is analogous to GeoSciMLv3.2 compound material particle geometry description.  "@en ;
+    owl:imports gsoc:ontology,
+        gsog:ontology ;
+    skos:definition "Kinds of rock material."@en ;
+    skos:prefLabel "Geoscience Ontology, Rock Types"@en ;
+    schema:codeRepository "https://github.com/Loop3D/GKM" .
+
+gsrm:phyllic_altered_rock a owl:Class ;
+    rdfs:label "phyllic altered rock"@en ;
+    dct:source "https://en.wikipedia.org/wiki/Phyllic_alteration"@en ;
+    rdfs:comment "Altered rock characterised by the assemblage of quartz + sericite + pyrite, and occurs at high temperatures and moderately acidic (low pH) conditions. Typically associated with copper porphyry ore deposits in calc-alkaline rocks."@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:potassic_altered_rock a owl:Class ;
+    rdfs:label "potassic altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:propylitic_altered_rock a owl:Class ;
+    rdfs:label "propylitic altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:pyritic_altered_rock a owl:Class ;
+    rdfs:label "pyritic altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:red_rock_altered_rock a owl:Class ;
+    rdfs:label "red rock altered rock"@en ;
+    dct:source "Williams, P.J., 1994, Aust. J. Earth Science, v41, p381-382",
+        "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "Alteration characterized by finely dispersed hematite"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:residual_material a owl:Class ;
+    rdfs:label "residual material"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Material of composite origin resulting from weathering processes at the Earth's surface, with genesis dominated by removal of chemical constituents by aqueous leaching. Miinor clastic, chemical, or organic input may also contribute. Consolidation state is not inherent in definition, but typically material is unconsolidated or weakly consolidated."@en ;
+    rdfs:subClassOf gsrm:material_formed_in_surficial_environment .
+
+gsrm:saussuritised_rock a owl:Class ;
+    rdfs:label "saussuritised rock"@en ;
+    dct:source "https://www.britannica.com/science/saussuritization"@en ;
+    rdfs:comment "Rock in which calcium-bearing plagioclase feldspar is altered to an assemblage of minerals called saussurite, typically including zoisite, chlorite, amphibole, and carbonate minerals. Residual fluids present during the late stages of magmatic crystallization can react with previously formed plagioclase feldspar to form saussurite; the saussurite will be spread through the plagioclase or located near its outer margin. The plagioclase may be reconstituted into a more sodium-rich variety (albite), although the original form of the crystal is retained. Later hydrothermal alteration can produce the same result. Mafic rocks are especially susceptible to saussuritization owing to their high calcium content; the more calcium-rich portions of plagioclase in acidic rocks also are often saussuritized."@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:sericitic_altered_rock a owl:Class ;
+    rdfs:label "sericitic altered rock"@en ;
+    dct:source "https://en.wikipedia.org/wiki/Sericitic_alteration"@en ;
+    rdfs:comment "Rock in which plagioclase feldspar has been converted to sericite, an informal term for  fine-grained white phyllosilicate minerals. Commonly associated with phyllic altered rocks, used to describe less intense alteration."@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:serpentinised_rock a owl:Class ;
+    rdfs:label "serpentinised rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:silicified_rock a owl:Class ;
+    rdfs:label "silicificed rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:slightly_indurated a owl:Class ;
+    rdfs:label "slightly indurated"@en ;
+    dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "Rock can be broken with single blow from standard rock hammer (less than 1 kg mass)."@en ;
+    rdfs:subClassOf gsrm:indurated .
+
+gsrm:unconsolidated_loose a owl:Class ;
+    rdfs:label "unconsolidated loose"@en ;
+    dct:source "NADM sedimentary rock vocabulary NADM sedimentary rock vocabulary (https://pubs.usgs.gov/of/2004/1451/sltt/appendixC/appendixC_pdf.zip)  SLTTs 2004,  after Bowles 1985"@en ;
+    rdfs:comment "Easily shoveled, can be indented with fingers, Relative density 0.2-0.4."@en ;
+    rdfs:subClassOf gsrm:unconsolidated .
+
+gsrm:unconsolidated_very_loose a owl:Class ;
+    rdfs:label "unconsolidated very loose"@en ;
+    dct:source "NADM sedimentary rock vocabulary NADM sedimentary rock vocabulary (https://pubs.usgs.gov/of/2004/1451/sltt/appendixC/appendixC_pdf.zip)  SLTTs 2004,  after Bowles 1984"@en ;
+    rdfs:comment "Easily indented with fingers, Relative density 0.0-0.2."@en ;
+    rdfs:subClassOf gsrm:unconsolidated .
+
+gsrm:uralitised_rock a owl:Class ;
+    rdfs:label "uralitised rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:variable_induration a owl:Class ;
+    rdfs:label "variable induration"@en ;
+    dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "Material is lithified, but induration varies at scale of description."@en ;
+    rdfs:subClassOf gsrm:indurated .
+
+gsrm:well_consolidated a owl:Class ;
+    rdfs:label "well consolidated"@en ;
+    dct:source "NADM sedimentary rock vocabulary NADM sedimentary rock vocabulary (https://pubs.usgs.gov/of/2004/1451/sltt/appendixC/appendixC_pdf.zip)  SLTTs 2004,  after Bowles 1986"@en ;
+    rdfs:comment "Requires pick to loosen for shoveling, relative density 0.7-0.9."@en ;
+    rdfs:subClassOf gsrm:consolidated .
+
+gsrm:well_indurated a owl:Class ;
+    rdfs:label "well indurated"@en ;
+    dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "Particles in the rock are strongly bound together such that rock surface can only be broken with great difficulty using standard rock hammer (less than 1 kg mass)."@en ;
+    rdfs:subClassOf gsrm:indurated .
+
+gsrm:zeolitic_altered_rock a owl:Class ;
+    rdfs:label "zeolitic altered rock"@en ;
+    dct:source "CGI alterationtype SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "definition missing"@en ;
+    rdfs:subClassOf gsrm:altered_rock .
+
+gsrm:Acidic_Igneous_Material a owl:Class ;
+    rdfs:label "acidic igneous material"@en ;
+    dct:source "after LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous material with more than 63 percent SiO2."@en ;
+    rdfs:subClassOf gsrm:Igneous_Material .
+
+gsrm:Andesite a owl:Class ;
+    rdfs:label "andesite"@en ;
+    dct:source "after LeMaitre et al. 2002"@en ;
+    rdfs:comment "Fine-grained igneous rock with less than 20 percent quartz and less than 10 percent feldspathoid minerals in the QAPF fraction, in which the ratio of plagioclase to total feldspar is greater 0.65. Includes rocks defined modally in QAPF fields 9 and 10 or chemically in TAS field O2 as andesite. Basalt and andesite, which share the same QAPF fields, are distinguished chemically based on silica content, with basalt defined to contain less than 52 weight percent silica. If chemical data are not available, the color index is used to distinguish the categories, with basalt defined to contain greater than 35 percent mafic minerals by volume or greater than 40 percent mafic minerals by weight. Typically consists of plagioclase (frequently zoned from labradorite to oligoclase), pyroxene, hornblende and/or biotite. Fine grained equivalent of dioritic rock."@en,
+        "Note the mela-andesite and leuco-basalt categories are not recommended in this system. If chemical analytical data are available to constrain the silica content, the basalt or andesite category should be used."@en ;
+    rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock,
+        gsrm:Intermediate_Composition_Igneous_Rock ;
+    gsmin:mindatid "min-48484" ;
+    gsmin:mindaturl "https://mindat.org/min-48484.html" .
+
+gsrm:Anthropogenic_Material a owl:Class ;
+    rdfs:label "anthropogenic material"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Material known to have artificial (human-related) origin; insufficient information to classify in more detail."@en ;
+    rdfs:subClassOf gsog:Rock_Material .
+
+gsrm:Basic_Igneous_Material a owl:Class ;
+    rdfs:label "basic igneous material"@en ;
+    dct:source "after LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous material with between 45 and 52 percent SiO2."@en ;
+    rdfs:subClassOf gsrm:Igneous_Material .
+
+gsrm:Carbonate_Mud a owl:Class ;
+    rdfs:label "carbonate mud"@en ;
+    dct:source "follow pattern used for clastic sand and mud categories, based on SLTTs 2004"@en ;
+    rdfs:comment "Carbonate sediment composed of less than 25 percent clasts that have a maximum diameter more than 2 mm, and the ratio of sand size to mud size clasts is less than one."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sediment,
+        gsrm:Mud_Size_Sediment ;
+    skos:altLabel "marl"@en .
+
+gsrm:Consolidation_Degree a owl:Class ;
+    rdfs:label "Consolidation degree"@en ;
+    rdfs:comment "A property that specifies the degree to which an aggregation of EarthMaterial particles is a distinct solid material. Consolidation and induration are related concepts specified by this property. They define a continuum from unconsolidated material to very hard rock. Induration is the degree to which a consolidated material is made hard, operationally determined by how difficult it is to break a piece of the material. Consolidated materials may have varying degrees of induration (NADMSC, 2004)"@en ;
+    rdfs:isDefinedBy "GeoSciML v4"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom gsog:Rock_Material ;
+            owl:onProperty gsoc:isQualityOf ],
+        [ a owl:Restriction ;
+            owl:onClass gsog:Rock_Material ;
+            owl:onProperty gsoc:isQualityOf ;
+            owl:qualifiedCardinality "1"^^xsd:nonNegativeInteger ],
+        gsoc:Physical_Quality .
+
+gsrm:Fragmental_Igneous_Rock a owl:Class ;
+    rdfs:label "fragmental igneous rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Igneous rock in which greater than 75 percent of the rock consists of fragments produced as a result of igneous rock-forming process. Includes pyroclastic rocks, autobreccia associated with lava flows and intrusive breccias. Excludes deposits reworked by epiclastic processes (see Tuffite)"@en ;
+    rdfs:subClassOf gsrm:Fragmental_Igneous_Material,
+        gsrm:Igneous_Rock .
+
+gsrm:Generic_Conglomerate a owl:Class ;
+    rdfs:label "generic conglomerate"@en ;
+    dct:source "Neuendorf et al. 2005; SLTTs 2004; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
+    rdfs:comment "Sedimentary rock composed of at least 30 percent rounded to subangular fragments larger than 2 mm in diameter; typically contains finer grained material in interstices between larger fragments. If more than 15 percent of the fine grained matrix is of indeterminant clastic or diagenetic origin and the fabric is matrix supported, may also be categorized as wackestone. If rock has unsorted or poorly sorted texture with a wide range of particle sizes, may also be categorized as diamictite."@en ;
+    rdfs:subClassOf gsrm:Sedimentary_Rock .
+
+gsrm:Generic_Sandstone a owl:Class ;
+    rdfs:label "generic sandstone"@en ;
+    dct:source "SLTTs 2004; Neuendorf et al. 2005; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
+    rdfs:comment "Sedimentary rock in which less than 30 percent of particles are greater than 2 mm in diameter (gravel) and the sand to mud ratio is at least 1."@en ;
+    rdfs:subClassOf gsrm:Sedimentary_Rock .
+
+gsrm:Glass_Rich_Igneous_Rock a owl:Class ;
+    rdfs:label "glass rich igneous rock"@en ;
+    dct:source "This vocabulary, based on Gillespie and Styles 1999"@en ;
+    rdfs:comment "Igneous rock that contains greater than 50 percent massive glass."@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock .
+
+gsrm:Granofels a owl:Class ;
+    rdfs:label "granofels"@en ;
+    dct:source "SLTTm 2004"@en ;
+    rdfs:comment "Metamorphic rock with granoblastic fabric and very little or no foliation (less than 10 percent of the mineral grains in the rock are elements in a planar or linear fabric). Grainsize not specified."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock ;
+    gsmin:mindatid "min-48633" ;
+    gsmin:mindaturl "https://mindat.org/min-48633.html" .
+
+gsrm:Intermediate_Composition_Igneous_Material a owl:Class ;
+    rdfs:label "intermediate composition igneous material"@en ;
+    dct:source "after LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous material with between 52 and 63 percent SiO2."@en ;
+    rdfs:subClassOf gsrm:Igneous_Material .
+
+gsrm:Mylonitic_Rock a owl:Class ;
+    rdfs:label "mylonitic rock"@en ;
+    dct:source "Marshak and Mitra 1988"@en ;
+    rdfs:comment "Metamorphic rock characterised by a foliation resulting from tectonic grain size reduction, in which more than 10 percent of the rock volume has undergone grain size reduction. Includes protomylonite, mylonite, ultramylonite, and blastomylonite."@en ;
+    rdfs:subClassOf gsrm:Foliated_Metamorphic_Rock,
+        gsrm:fault_related_material .
+
+gsrm:Non_Clastic_Siliceous_Sedimentary_Rock a owl:Class ;
+    rdfs:label "non clastic siliceous sedimentary rock"@en ;
+    dct:source "modified from SLTTs 2004"@en ;
+    rdfs:comment "Definition updated to include chert, flint SMR 2020-09-21"@en,
+        "Sedimentary rock that consists of at least 50 percent silicate mineral material, deposited directly by chemical or biological processes at the depositional surface, in particles formed by chemical or biological processes within the basin of deposition, or formed by diagenetic processes. Includes chert and flint found in carbonate rocks."@en ;
+    rdfs:subClassOf gsrm:Non_Clastic_Siliceous_Sedimentary_Material,
+        gsrm:Sedimentary_Rock .
+
+gsrm:Organic_Rich_Sedimentary_Rock a owl:Class ;
+    rdfs:label "organic rich sedimentary rock"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sapropelic coal, and asphaltite are not differentiated in This vocabulary"@en,
+        "Sedimentary rock with color, composition, texture and apparent density indicating greater than 50 percent organic content by weight on a moisture-free basis."@en ;
+    rdfs:subClassOf gsrm:Organic_Rich_Sedimentary_Material,
+        gsrm:Sedimentary_Rock .
+
+gsrm:Sand_Size_Sediment a owl:Class ;
+    rdfs:label "sand size sediment"@en ;
+    dct:source "Neuendorf et al. 2005 ; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
+    rdfs:comment "Sediment in which less than 30 percent of particles are gravel (greater than 2 mm in diameter) and the sand to mud ratio is at least 1. composition or genesis of clasts not specified."@en ;
+    rdfs:subClassOf gsrm:Sediment .
+
+gsrm:Schist a owl:Class ;
+    rdfs:label "schist"@en ;
+    dct:source "SLTTm 2004; Neuendorf et al. 2005"@en ;
+    rdfs:comment "Foliated phaneritic metamorphic rock with well developed, continuous schistosity, meaning that greater than 50 percent of the rock by volume is mineral grains with a thin tabular, lamellar, or acicular prismatic crystallographic habit that are oriented in a continuous planar or linear fabric."@en ;
+    rdfs:subClassOf gsrm:Foliated_Metamorphic_Rock ;
+    gsmin:mindatid "min-48640" ;
+    gsmin:mindaturl "https://mindat.org/min-48640.html" .
+
+gsrm:Silicate_Mud a owl:Class ;
+    rdfs:label "silicate mud"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Mud size sediment that consists of less than 50 percent carbonate minerals."@en ;
+    rdfs:subClassOf gsrm:Mud_Size_Sediment .
+
+gsrm:Basalt a owl:Class ;
+    rdfs:label "basalt"@en ;
+    dct:source "after LeMaitre et al. 2002"@en ;
+    rdfs:comment "Fine-grained or porphyritic igneous rock with less than 20 percent quartz, and less than 10 percent feldspathoid minerals, in which the ratio of plagioclase to total feldspar is greater 0.65. Typically composed of calcic plagioclase and clinopyroxene; phenocrysts typically include one or more of calcic plagioclase, clinopyroxene, orthopyroxene, and olivine. Includes rocks defined modally in QAPF fields 9 and 10 or chemically in TAS field B as basalt. Basalt and andesite are distinguished chemically based on silica content, with basalt defined to contain less than 52 weight percent silica. If chemical data are not available, the color index is used to distinguish the categories, with basalt defined to contain greater than 35 percent mafic minerals by volume or greater than 40 percent mafic minerals by weight."@en ;
+    rdfs:subClassOf gsrm:Basic_Igneous_Rock,
+        gsrm:Fine_Grained_Igneous_Rock ;
+    gsmin:mindatid "min-48492" ;
+    gsmin:mindaturl "https://mindat.org/min-48492.html" .
+
+gsrm:Basic_Igneous_Rock a owl:Class ;
+    rdfs:label "basic igneous rock"@en ;
+    dct:source "after LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous rock with between 45 and 52 percent SiO2."@en ;
+    rdfs:subClassOf gsrm:Basic_Igneous_Material,
+        gsrm:Igneous_Rock .
+
+gsrm:Biogenic_Sediment a owl:Class ;
+    rdfs:label "biogenic sediment"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Corresponding biogenic sedimentary material and biogenic sedimentary rock categories are not included based on the interpretation that biogenic sedimentary rock will be in a different category, e.g. carbonate sedimentary rock or organic rich sedimentary rock."@en,
+        "Sediment composed of greater than 50 percent material of biogenic origin. Because the biogenic material may be skeletal remains that are not organic, all biogenic sediment is not necessarily organic-rich."@en ;
+    rdfs:subClassOf gsrm:Sediment .
+
+gsrm:Calcareous_Carbonate_Sediment a owl:Class ;
+    rdfs:label "calcareous carbonate sediment"@en ;
+    dct:source "after Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Carbonate sediment with a calcite (plus aragonite) to dolomite ratio greater than 1 to 1. Includes lime-sediments."@en ;
+    rdfs:subClassOf gsrm:Calcareous_Carbonate_Sedimentary_Material,
+        gsrm:Carbonate_Sediment .
+
+gsrm:Calcareous_Carbonate_Sedimentary_Material a owl:Class ;
+    rdfs:label "calcareous carbonate sedimentary material"@en ;
+    dct:source "after Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Carbonate sedimentary material of unspecified consolidation state with a calcite (plus aragonite) to dolomite ratio greater than 1 to 1. Includes lime-sediments, limestone and dolomitic limestone."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Material .
+
+gsrm:Calcareous_Carbonate_Sedimentary_Rock a owl:Class ;
+    rdfs:label "calcareous carbonate sedimentary rock"@en ;
+    dct:source "SLTTs 2004; Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Carbonate sedimentary rock with a calcite (plus aragonite) to dolomite ratio greater than 1 to 1. Includes limestone and dolomitic limestone."@en ;
+    rdfs:subClassOf gsrm:Calcareous_Carbonate_Sedimentary_Material,
+        gsrm:Carbonate_Sedimentary_Rock .
+
+gsrm:Clastic_Sandstone a owl:Class ;
+    rdfs:label "sandstone"@en ;
+    dct:source "SLTTs 2004; Neuendorf et al. 2005; particle size from Wentworth grade scale"@en ;
+    rdfs:comment "Clastic sedimentary rock in which less than 30 percent of particles are greater than 2 mm in diameter (gravel) and the sand to mud ratio is at least 1."@en,
+        "Note this category is equivalent to cagetory labeled 'sandy rock' in SLTTs (2004), not to the much more restricted category labeled 'Sandstone' in that system."@en ;
+    rdfs:subClassOf gsrm:Clastic_Sedimentary_Rock,
+        gsrm:Generic_Sandstone ;
+    skos:altLabel "clastic sandstone"@en,
+        "sandy rock"@en ;
+    gsmin:mindatid "min-49438" ;
+    gsmin:mindaturl "https://mindat.org/min-49438.html" .
+
+gsrm:Clastic_Sedimentary_Material a owl:Class ;
+    rdfs:label "clastic sedimentary material"@en ;
+    dct:source "SLTTs 2004; Neuendorf et al. 2005"@en ;
+    rdfs:comment "Sedimentary material of unspecified consolidation state in which at least 50 percent of the constituent particles were derived from erosion, weathering, or mass-wasting of pre-existing earth materials, and transported to the place of deposition by mechanical agents such as water, wind, ice and gravity."@en ;
+    rdfs:subClassOf gsrm:Sedimentary_Material .
+
+gsrm:Dioritoid a owl:Class ;
+    rdfs:label "dioritoid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline igneous rock with M less than 90, consisting of intermediate plagioclase, commonly with hornblende and often with biotite or augite. Plagioclase to total feldspar ratio is greater that 0.65, and anorthite content of plagioclase is less than 50 percent. Less than 10 percent feldspathoid mineral and less than 20 percent quartz in the QAPF fraction. Includes rocks defined modally in QAPF fields 9 and 10 (and their subdivisions)."@en ;
+    rdfs:subClassOf gsrm:Intermediate_Composition_Igneous_Rock,
+        gsrm:Phaneritic_Igneous_Rock ;
+    gsmin:mindatid "min-48224" ;
+    gsmin:mindaturl "https://mindat.org/min-48224.html" .
+
+gsrm:Dolomitic_Or_Magnesian_Sedimentary_Material a owl:Class ;
+    rdfs:label "dolomitic or magnesian sedimentary material"@en ;
+    dct:source "after SLTTs 2004, Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Carbonate sedimentary material of unspecified consolidation degree with a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1. Includes dolomite sediment, dolostone, lime dolostone and magnesite-stone."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Material .
+
+gsrm:Dolomitic_Or_Magnesian_Sedimentary_Rock a owl:Class ;
+    rdfs:label "dolomitic or magnesian sedimentary rock"@en ;
+    dct:source "after SLTTs 2004, Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Carbonate sedimentary rock with a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1. Includes dolostone, lime dolostone and magnesite-stone."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock,
+        gsrm:Dolomitic_Or_Magnesian_Sedimentary_Material .
+
+gsrm:Dolomitic_Sediment a owl:Class ;
+    rdfs:label "dolomitic sediment"@en ;
+    dct:source "after SLTTs 2004, Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Carbonate sediment with a ratio of magnesium carbonate to calcite (plus aragonite) greater than 1 to 1."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sediment,
+        gsrm:Dolomitic_Or_Magnesian_Sedimentary_Material .
+
+gsrm:Foid_Dioritoid a owl:Class ;
+    rdfs:label "foid dioritoid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline igneous rock in which M is less than 90, the plagioclase to total feldspar ratio is greater than 0.5, feldspathoid minerals form 10-60 percent of the QAPF fraction, plagioclase has anorthite content less than 50 percent. These rocks typically contain large amounts of mafic minerals. Includes rocks defined modally in QAPF fields 13 and 14."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock .
+
+gsrm:Foid_Gabbroid a owl:Class ;
+    rdfs:label "foid gabbroid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline igneous rock in which M is less than 90, the plagioclase to total feldspar ratio is greater than 0.5, feldspathoids form 10-60 percent of the QAPF fraction, and plagioclase has anorthite content greater than 50 percent. These rocks typically contain large amounts of mafic minerals. Includes rocks defined modally in QAPF fields 13 and 14."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock .
+
+gsrm:Foid_Syenitoid a owl:Class ;
+    rdfs:label "foid syenitoid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline igneous rock with M less than 90, contains between 10 and 60 percent feldspathoid mineral in the QAPF fraction, and has a plagioclase to total feldspar ratio less than 0.5. Includes QAPF fields 11 and 12."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock .
+
+gsrm:Fragmental_Igneous_Material a owl:Class ;
+    rdfs:label "fragmental igneous material"@en ;
+    dct:source "CGI concept definition task group"@en ;
+    rdfs:comment "igneous_material of unspecified consolidation state in which greater than 75 percent of the rock consists of fragments produced as a result of igneous rock-forming process."@en ;
+    rdfs:subClassOf gsrm:Igneous_Material .
+
+gsrm:Gabbroid a owl:Class ;
+    rdfs:label "gabbroid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline igneous rock that contains less than 90 percent mafic minerals, and up to 20 percent quartz or up to 10 percent feldspathoid in the QAPF fraction. The ratio of plagioclase to total feldspar is greater than 0.65, and anorthite content of the plagioclase is greater than 50 percent. Includes rocks defined modally in QAPF fields 9 and 10 and their subdivisions."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
+    gsmin:mindatid "min-48265" ;
+    gsmin:mindaturl "https://mindat.org/min-48265.html" .
+
+gsrm:Gneiss a owl:Class ;
+    rdfs:label "gneiss"@en ;
+    dct:source "Neuendorf et al. 2005"@en ;
+    rdfs:comment "Foliated metamorphic rock with bands or lenticles rich in granular minerals alternating with bands or lenticles rich in minerals with a flaky or elongate prismatic habit. Mylonitic foliation or well developed, continuous schistosity (greater than 50 percent of the rock consists of grains participate in a planar or linear fabric) precludes classification with this concept."@en ;
+    rdfs:subClassOf gsrm:Foliated_Metamorphic_Rock ;
+    gsmin:mindatid "min-48629" ;
+    gsmin:mindaturl "https://mindat.org/min-48629.html" .
+
+gsrm:Granite a owl:Class ;
+    rdfs:label "granite"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline rock consisting of quartz, alkali feldspar and plagioclase (typically sodic) in variable amounts, usually with biotite and/or hornblende. Includes rocks defined modally in QAPF Field 3."@en ;
+    rdfs:subClassOf gsrm:Granitoid ;
+    gsmin:mindatid "min-48141" ;
+    gsmin:mindaturl "https://mindat.org/min-48141.html" .
+
+gsrm:High_Magnesium_Fine_Grained_Igneous_Rock a owl:Class ;
+    rdfs:label "high magnesium fine grained igneous rock"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "fine-grained igneous rock that contains unusually high concentration of MgO. For rocks that contain greater than 52 percent silica, MgO must be greater than 8 percent. For rocks containing less than 52 percent silica, MgO must be greater than 12 percent."@en ;
+    rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock .
+
+gsrm:Impure_Carbonate_Sediment a owl:Class ;
+    rdfs:label "impure carbonate sediment"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Carbonate sediment in which between 50 and 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sediment ;
+    skos:altLabel "marl"@en .
+
+gsrm:Impure_Carbonate_Sedimentary_Rock a owl:Class ;
+    rdfs:label "impure carbonate sedimentary rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Sedimentary rock in which between 50 and 90 percent of the primary and/or recrystallized constituents are composed of carbonate minerals."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock ;
+    skos:altLabel "marlstone"@en .
+
+gsrm:Intermediate_Composition_Igneous_Rock a owl:Class ;
+    rdfs:label "intermediate composition igneous rock"@en ;
+    dct:source "after LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous rock with between 52 and 63 percent SiO2."@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock,
+        gsrm:Intermediate_Composition_Igneous_Material .
+
+gsrm:Iron_Rich_Sedimentary_Material a owl:Class ;
+    rdfs:label "iron rich sedimentary material"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sedimentary material of unspecified consolidation state that consists of at least 50 percent iron-bearing minerals (hematite, magnetite, limonite-group, siderite, iron-sulfides), as determined by hand-lens or petrographic analysis. Corresponds to a rock typically containing 15 percent iron by weight."@en ;
+    rdfs:subClassOf gsrm:Chemical_Sedimentary_Material .
+
+gsrm:Limestone a owl:Class ;
+    rdfs:label "limestone"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Pure carbonate sedimentary rock with a calcite (plus aragonite) to dolomite ratio greater than 1 to 1. Includes limestone and dolomitic limestone."@en ;
+    rdfs:subClassOf gsrm:Calcareous_Carbonate_Sedimentary_Rock,
+        gsrm:Pure_Carbonate_Sedimentary_Rock ;
+    gsmin:mindatid "min-49160" ;
+    gsmin:mindaturl "https://mindat.org/min-49160.html" .
+
+gsrm:Massive_Sulphide a owl:Class ;
+    rdfs:label "Massive sulphide"@en ;
+    dct:source "Provisional SMR 2020-06-07"@en ;
+    rdfs:comment "rock consisting of greater than 50% sulphide or sulfosalt minerals formed by any processes. Includes hydrothermal and sedimentary ehalative sulfide."@en ;
+    rdfs:subClassOf gsrm:Rock ;
+    skos:altLabel "Massive Sulfide"@en .
+
+gsrm:Mud a owl:Class ;
+    rdfs:label "mud"@en ;
+    dct:source "definition of mud from SLTTs 2004 muddy sediment; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
+    rdfs:comment "Clastic sediment consisting of less than 30 percent gravel-size (2 mm) particles and with a mud-size to sand-size particle ratio greater than 1. More than half of the particles are of epiclastic origin."@en ;
+    rdfs:subClassOf gsrm:Clastic_Sediment,
+        gsrm:Mud_Size_Sediment ;
+    gsmin:mindatid "min-49426" ;
+    gsmin:mindaturl "https://mindat.org/min-49426.html" .
+
+gsrm:Natural_Unconsolidated_Material a owl:Class ;
+    rdfs:label "natural unconsolidated material"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Unconsolidated material known to have natural, ie. not human-made, origin."@en ;
+    rdfs:subClassOf gsrm:Unconsolidated_Material .
+
+gsrm:Non_Clastic_Siliceous_Sedimentary_Material a owl:Class ;
+    rdfs:label "non clastic siliceous sedimentary material"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sedimentary material that consists of at least 50 percent silicate mineral material, deposited directly by chemical or biological processes at the depositional surface, or in particles formed by chemical or biological processes within the basin of deposition."@en ;
+    rdfs:subClassOf gsrm:Sedimentary_Material .
+
+gsrm:Ooze a owl:Class ;
+    rdfs:label "ooze"@en ;
+    dct:source "based on Bates and Jackson 1987 and Hallsworth and Knox 1999"@en ;
+    rdfs:comment "Biogenic sediment consisting of less than 1 percent gravel-size (greater than or equal to 2 mm) particles, with a sand to mud ratio less than 1 to 9, and less than 50 percent carbonate minerals."@en,
+        "Neuendorf et al. 2005 put cutoff at 30 percent skeletal remains; this is raised to 50 percent in This vocabulary for consistency with definition of other Biogenic sediment category"@en ;
+    rdfs:subClassOf gsrm:Biogenic_Sediment,
+        gsrm:Mud_Size_Sediment ;
+    skos:altLabel "biogenic mud"@en ;
+    gsmin:mindatid "min-50894" ;
+    gsmin:mindaturl "https://mindat.org/min-50894.html" .
+
+gsrm:Organic_Rich_Sediment a owl:Class ;
+    rdfs:label "organic rich sediment"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sediment with color, composition, texture and apparent density indicating greater than 50 percent organic content by weight on a moisture-free basis."@en,
+        "The broader relation from organic rich sediment to biogenic sediment is based on the inference that organic rich material is always biogenic in origin. Biogenic is a broader category because not all biogenic materials are organic rich, for example shells or phosphatic bone."@en ;
+    rdfs:subClassOf gsrm:Biogenic_Sediment,
+        gsrm:Organic_Rich_Sedimentary_Material .
+
+gsrm:Organic_Rich_Sedimentary_Material a owl:Class ;
+    rdfs:label "organic rich sedimentary material"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sedimentary material in which 50 percent or more of the primary sedimentary material is organic carbon."@en ;
+    rdfs:subClassOf gsrm:Sedimentary_Material .
+
+gsrm:Phonolitoid a owl:Class ;
+    rdfs:label "phonolitoid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Fine grained igneous rock than contains less than 90 percent mafic minerals, between 10 and 60 percent feldspathoid mineral in the QAPF fraction and has a plagioclase to total feldspar ratio less than 0.5. Includes rocks defined modally in QAPF fields 11 and 12, and TAS field Ph."@en ;
+    rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
+    skos:altLabel "phonolitic rock"@en ;
+    gsmin:mindatid "min-50696" ;
+    gsmin:mindaturl "https://mindat.org/min-50696.html" .
+
+gsrm:Phosphate_Rich_Sedimentary_Material a owl:Class ;
+    rdfs:label "phosphate rich sedimentary material"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sedimentary material in which at least 50 percent of the primary and/or recrystallized constituents are phosphate minerals."@en ;
+    rdfs:subClassOf gsrm:Sedimentary_Material .
+
+gsrm:Pure_Carbonate_Sediment a owl:Class ;
+    rdfs:label "pure carbonate sediment"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Carbonate sediment in which greater than 90 percent of the constituents are composed of one (or more) of the carbonate minerals in particles of intrabasinal origin."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sediment .
+
+gsrm:Pyroclastic_Material a owl:Class ;
+    rdfs:label "pyroclastic material"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Fragmental igneous material that consists of more than 75 percent of particles formed by disruption as a direct result of volcanic action."@en ;
+    rdfs:subClassOf gsrm:Fragmental_Igneous_Material .
+
+gsrm:Pyroclastic_Rock a owl:Class ;
+    rdfs:label "pyroclastic rock"@en ;
+    dct:source "based on LeMaitre et al. 2002"@en ;
+    rdfs:comment "Fragmental igneous rock that consists of greater than 75 percent fragments produced as a direct result of eruption or extrusion of magma from within the earth onto its surface. Includes autobreccia associated with lava flows and excludes deposits reworked by epiclastic processes."@en ;
+    rdfs:subClassOf gsrm:Fragmental_Igneous_Rock,
+        gsrm:Pyroclastic_Material .
+
+gsrm:Rhyolitoid a owl:Class ;
+    rdfs:label "rhyolitoid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Note that technical definition, based on modal mineralogy plotted in a QAPF triangle may be applied qualitatively, based on phenocryst mineralogy when ground mass mineralogy can not be determined optically, or based on CIPW norm. Although TAS categories are defined based on chemical analyses, the correspondence with the QAPF defined categories is generally close enough that QAPF categories are commonly used interchangeably with TAS categories. It is important to note the basis for assignment of fine-grained igneous rocks to a specifice lithology category."@en,
+        "fine_grained_igneous_rock consisting of quartz and alkali feldspar, with minor plagioclase and biotite, in a microcrystalline, cryptocrystalline or glassy groundmass. Flow texture is common. Includes rocks defined modally in QAPF fields 2 and 3 or chemically in TAS Field R as rhyolite. QAPF normative definition is based on modal mineralogy thus: less than 90 percent mafic minerals, between 20 and 60 percent quartz in the QAPF fraction, and ratio of plagioclse to total feldspar is less than 0.65."@en ;
+    rdfs:subClassOf gsrm:Acidic_Igneous_Rock,
+        gsrm:Fine_Grained_Igneous_Rock ;
+    skos:altLabel "rhyolitic rock"@en ;
+    gsmin:mindatid "min-50639" ;
+    gsmin:mindaturl "https://mindat.org/min-50639.html" .
+
+gsrm:Tephra a owl:Class ;
+    rdfs:label "tephra"@en ;
+    dct:source "Hallsworth and Knox 1999; LeMaitre et al. 2002"@en ;
+    rdfs:comment "Unconsolidated pyroclastic material in which greater than 75 percent of the fragments are deposited as a direct result of volcanic processes and the deposit has not been reworked by epiclastic processes. Includes ash, lapilli tephra, bomb tephra, block tephra and unconsolidated agglomerate."@en ;
+    rdfs:subClassOf gsrm:Natural_Unconsolidated_Material,
+        gsrm:Pyroclastic_Material .
+
+gsrm:Unconsolidated_Material a owl:Class ;
+    rdfs:label "unconsolidated material"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "compoundMaterial composed of an aggregation of particles that do not adhere to each other strongly enough that the aggregate can be considered a solid in its own right."@en ;
+    rdfs:subClassOf gsog:Rock_Material .
+
+gsrm:consolidated a owl:Class ;
+    rdfs:label "consolidated"@en ;
+    dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "Particulate constituents of a compound material adhere to each other strongly enough that the aggregate can be considered a solid material in its own right."@en ;
+    rdfs:subClassOf gsrm:Consolidation_Degree_Value .
+
+gsrm:Alkali_Feldspar_Syenitic_Rock a owl:Class ;
+    rdfs:label "alkali feldspar syenitic rock"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Syenitoid with a plagioclase to total feldspar ratio of less than 0.1. QAPF fields 6, 6*, and 6'."@en ;
+    rdfs:subClassOf gsrm:Syenitoid .
+
+gsrm:Alkali_Feldspar_Trachytic_Rock a owl:Class ;
+    rdfs:label "alkali feldspar trachytic rock"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Trachytoid that has a plagioclase to total feldspar ratio less than 0.1. QAPF fields 6, 6', and 6*."@en ;
+    rdfs:subClassOf gsrm:Trachytoid .
+
+gsrm:Anorthositic_Rock a owl:Class ;
+    rdfs:label "anorthositic rock"@en ;
+    dct:source "LeMaitre et al. 2002; This vocabulary"@en ;
+    rdfs:comment "Anorthositic rock term invented to label the combined QAPF fields 10, 10*, and 10', in order to construct hierarchy in this vocabulary."@en,
+        "Leucocratic phaneritic crystalline igneous rock consisting essentially of plagioclase, often with small amounts of pyroxene. By definition, colour index M is less than 10, and plagiclase to total feldspar ratio is greater than 0.9. Less than 20 percent quartz and less than 10 percent feldspathoid in the QAPF fraction. QAPF field 10, 10*, and 10'."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock .
+
+gsrm:Clastic_Mudstone a owl:Class ;
+    rdfs:label "mudstone"@en ;
+    dct:source "Pettijohn et al. 1987 referenced in Hallsworth and Knox 1999."@en ;
+    rdfs:comment "Clastic sedimentary rock consisting of less than 30 percent gravel-size (2 mm) particles and with a mud to sand ratio greater than 1."@en,
+        "Distinction of intrabasinal, diagenetic, or clastic genesis for very fine-grained carbonate minerals is interpretive in many cases. If there is uncertainty on the mudstone category based on intrabasinal vs epiclastic distinction required for clastic sedimentary rock-carbonate sedimentary rock categorization in this system, it is recommended to use the generic_mudstone category. This category is the union of the various fields labeled 'mudstone' with various qualifiers in Folk, 1954, Figure 1a, although Folk's (1954) category labeled 'mudstone' is a much more restricted category. The CGI category is equivalent to category labeled 'Mudrock' in SLTTs (2004), not to the category labeled 'Mudstone' adopted by that system from Folk (1954). Schnurrenberger, D., Russell, J. and Kelts, K., 2003, Classification of lacustrine sediments based on sedimentary components: Journal of Paleolimnology, v.29, p141-154."@en ;
+    rdfs:subClassOf gsrm:Clastic_Sedimentary_Rock,
+        gsrm:Generic_Mudstone ;
+    skos:altLabel "clastic mudstone"@en,
+        "mudrock"@en ;
+    gsmin:mindatid "min-49442" ;
+    gsmin:mindaturl "https://mindat.org/min-49442.html" .
+
+gsrm:Coal a owl:Class ;
+    rdfs:label "kohle"@de,
+        "coal"@en ;
+    dct:source "Economic commission for Europe, committee on Sustainable Energy- United Nations (ECE-UN), 1998, International Classification of in-Seam Coals: Energy 19, 41 pp."@en ;
+    rdfs:comment "A consolidated organic sedimentary material having less than 75% moisture. This category includes low, medium, and high rank coals according to International Classification of In-Seam Coal (United Nations, 1998), thus including lignite. Sapropelic coal is not distinguished in this category from humic coals. Formed from the compaction or induration of variously altered plant remains similar to those of peaty deposits."@en ;
+    rdfs:subClassOf gsrm:Organic_Rich_Sedimentary_Rock ;
+    gsmin:mindatid "min-9353" ;
+    gsmin:mindaturl "https://mindat.org/min-9353.html" .
+
+gsrm:Dioritic_Rock a owl:Class ;
+    rdfs:label "dioritic rock"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline rock with M less than 90, consisting of intermediate plagioclase, commonly with hornblende and often with biotite or augite. A dioritoid with a plagioclase to total feldspar ratio (in the QAPF fraction) greater than 0.9. Includes rocks defined modally in QAPF fields 10, 10' and 10*."@en ;
+    rdfs:subClassOf gsrm:Dioritoid .
+
+gsrm:Evaporite a owl:Class ;
+    rdfs:label "evaporite"@en ;
+    dct:source "Jackson 1997; SLTTs 2004"@en ;
+    rdfs:comment "Nonclastic sedimentary rock composed of at least 50 percent non-carbonate salts, including chloride, sulfate or borate minerals; formed through precipitation of mineral salts from a saline solution (non-carbonate salt rock)."@en ;
+    rdfs:subClassOf gsrm:Chemical_Sedimentary_Material ;
+    gsmin:mindatid "min-49338" ;
+    gsmin:mindaturl "https://mindat.org/min-49338.html" .
+
+gsrm:Exotic_Composition_Igneous_Rock a owl:Class ;
+    rdfs:label "exotic composition igneous rock"@en ;
+    dct:source "Gillespie and Styles 1999; LeMaitre et al. 2002"@en ;
+    rdfs:comment "Rock with 'exotic' mineralogical, textural or field setting characteristics; typically dark colored, with abundant phenocrysts. Criteria include: presence of greater than 10 percent melilite or leucite, or presence of kalsilite, or greater than 50 percent carbonate minerals. Includes Carbonatite, Melilitic rock, Kalsilitic rocks, Kimberlite, Lamproite, Leucitic rock and Lamprophyres."@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock .
+
+gsrm:Gabbroic_Rock a owl:Class ;
+    rdfs:label "gabbroic rock"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Gabbroid that has a plagioclase to total feldspar ratio greater than 0.9 in the QAPF fraction. Includes QAPF fields 10*, 10, and 10'. This category includes the various categories defined in LeMaitre et al. (2002) based on the mafic mineralogy, but apparently not subdivided based on the quartz/feldspathoid content."@en ;
+    rdfs:subClassOf gsrm:Basic_Igneous_Rock,
+        gsrm:Gabbroid .
+
+gsrm:Latitic_Rock a owl:Class ;
+    rdfs:label "latitic rock"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Trachytoid that has a plagioclase to total feldspar ratio between 0.35 and 0.65. QAPF fields 8, 8' and 8*."@en ;
+    rdfs:subClassOf gsrm:Trachytoid .
+
+gsrm:Monzodioritic_Rock a owl:Class ;
+    rdfs:label "monzodioritic rock"@en ;
+    dct:source "This vocabulary; LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline igneous rock consisting of sodic plagioclase (An0 to An50), alkali feldspar, hornblende and biotite, with or without pyroxene, and 0 to 10 percent feldspathoid or 0 to 20 percent quartz in the QAPF fraction. Plagioclase to total feldspar ratio in the QAPF fraction is between 0.65 and 0.9. Includes rocks defined modally in QAPF field 9, 9' and 9* as monzodiorite, foid-beaing monzodiorite, and quartz monzodiorite."@en ;
+    rdfs:subClassOf gsrm:Dioritoid .
+
+gsrm:Monzogabbroic_Rock a owl:Class ;
+    rdfs:label "monzogabbroic rock"@en ;
+    dct:source "LeMaitre et al. 2002, This vocabulary"@en ;
+    rdfs:comment "Gabbroid with a plagioclase to total feldspar ratio between 0.65 and 0.9. QAPF field 9, 9 prime and 9 asterisk"@en ;
+    rdfs:subClassOf gsrm:Gabbroid .
+
+gsrm:Monzonitic_Rock a owl:Class ;
+    rdfs:label "monzonitic rock"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Syenitoid with a plagioclase to total feldspar ratio between 0.35 and 0.65. Includes rocks in QAPF fields 8, 8*, and 8'."@en ;
+    rdfs:subClassOf gsrm:Syenitoid .
+
+gsrm:Pure_Carbonate_Sedimentary_Rock a owl:Class ;
+    rdfs:label "pure carbonate sedimentary rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Sedimentary rock in which greater than 90 percent of the primary and/or recrystallized constituents are carbonate minerals."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Rock .
+
+gsrm:Syenitic_Rock a owl:Class ;
+    rdfs:label "syenitic rock"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Syenitoid with a plagioclase to total feldspar ratio between 0.1 and 0.35. Includes rocks in QAPF fields 7, 7*, and 7'."@en ;
+    rdfs:subClassOf gsrm:Syenitoid .
+
+gsrm:Syenitoid a owl:Class ;
+    rdfs:label "syenitoid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline igneous rock with M less than 90, consisting mainly of alkali feldspar and plagioclase; minor quartz or nepheline may be present, along with pyroxene, amphibole or biotite. Ratio of plagioclase to total feldspar is less than 0.65, quartz forms less than 20 percent of QAPF fraction, and feldspathoid minerals form less than 10 percent of QAPF fraction. Includes rocks classified in QAPF fields 6, 7 and 8 and their subdivisions."@en ;
+    rdfs:subClassOf gsrm:Phaneritic_Igneous_Rock ;
+    gsmin:mindatid "min-48178" ;
+    gsmin:mindaturl "https://mindat.org/min-48178.html" .
+
+gsrm:Trachytic_Rock a owl:Class ;
+    rdfs:label "trachytic rock"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "LeMaitre et al. (2002) used 'trachyte' to refer to QAPF fields 7, 7', and 7* in the text (p. 30) as well as to the more restrictive category (QAPF field 7 only). The term Trachytic rock is introduced here to label this more general category of trachyte."@en,
+        "Trachytoid that has a plagioclase to total feldspar ratio between 0.1 and 0.35. QAPF fields 7, 7', and 7*."@en ;
+    rdfs:subClassOf gsrm:Trachytoid .
+
+gsrm:Trachytoid a owl:Class ;
+    rdfs:label "trachytoid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Fine grained igneous rock than contains less than 90 percent mafic minerals, less than 10 percent feldspathoid mineral and less than 20 percent quartz in the QAPF fraction and has a plagioclase to total feldspar ratio less than 0.65. Mafic minerals typically include amphibole or mica; typically porphyritic. Includes rocks defined modally in QAPF fields 6, 7 and 8 (with subdivisions) or chemically in TAS Field T as trachyte or latite."@en ;
+    rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
+    gsmin:mindatid "min-50641" ;
+    gsmin:mindaturl "https://mindat.org/min-50641.html" .
+
+gsrm:fault_related_material a owl:Class ;
+    rdfs:label "fault related material"@en ;
+    dct:source "This vocabulary; SLTTm 2004"@en ;
+    rdfs:comment "Material formed as a result brittle faulting, composed of greater than 10 percent matrix; matrix is fine-grained material caused by tectonic grainsize reduction. Includes cohesive (cataclasite series, mylonitic rocks) and non-cohesive (breccia-gouge series) material."@en ;
+    rdfs:subClassOf gsrm:Composite_Genesis_Material .
+
+gsrm:material_formed_in_surficial_environment a owl:Class ;
+    rdfs:label "material formed in surficial environment"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Material that is the product of weathering processes operating on pre-existing rocks or deposits, analogous to hydrothermal or metasomatic rocks, but formed at ambient Earth surface temperature and pressure."@en ;
+    rdfs:subClassOf gsrm:Composite_Genesis_Material .
+
+gsrm:unconsolidated a owl:Class ;
+    rdfs:label "unconsolidated"@en ;
+    dct:source "CGI consolidationdegree SKOS vocabulary 2012-11-24"@en ;
+    rdfs:comment "Particulate constituents of a compound material do not adhere to each other strongly enough that the aggregate can be considered a solid in its own right."@en ;
+    rdfs:subClassOf gsrm:Consolidation_Degree_Value .
+
+gsrm:Acidic_Igneous_Rock a owl:Class ;
+    rdfs:label "acidic igneous rock"@en ;
+    dct:source "after LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous rock with more than 63 percent SiO2."@en ;
+    rdfs:subClassOf gsrm:Acidic_Igneous_Material,
+        gsrm:Igneous_Rock .
+
+gsrm:Carbonate_Sedimentary_Material a owl:Class ;
+    rdfs:label "carbonate sedimentary material"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sedimentary material in which at least 50 percent of the primary and/or recrystallized constituents are composed of one (or more) of the carbonate minerals calcite, aragonite and dolomite, in particles of intrabasinal origin."@en,
+        "Should carbonate sedimentary material be considered a kind of chemical sedimentary material? Is biogenic precipitation a chemical sedimentary process?"@en ;
+    rdfs:subClassOf gsrm:Sedimentary_Material .
+
+gsrm:Chemical_Sedimentary_Material a owl:Class ;
+    rdfs:label "chemical sedimentary material"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sedimentary material that consists of at least 50 percent material produced by inorganic chemical processes within the basin of deposition. Includes inorganic siliceous, carbonate, evaporite, iron-rich, and phosphatic sediment classes."@en ;
+    rdfs:subClassOf gsrm:Sedimentary_Material .
+
+gsrm:Clastic_Sediment a owl:Class ;
+    rdfs:label "clastic sediment"@en ;
+    dct:source "SLTTs 2004; Neuendorf et al. 2005"@en ;
+    rdfs:comment "Choice of 'clastic' is purposful. Other suggested labels for this category include siliciclastic and terrigineous clastic. Siliciclastic is considered too limiting because the category includes rocks that consists clasts of carbonate minerals, e.g. epiclastic detritus eroded from carbonate rock. Terrigineous clastic was considered and rejected first because it is considered redundant, anything that is terrigineous is clastic. Second, it is questionable if clastic sediment derived by submarine processes (fragementation by gravity sliding, faulting, or volcanic activity, with transport by sediment gravity flow or submarine currents) is terrigineous, but it is clastic and is meant to be included in this category."@en,
+        "Sediment in which at least 50 percent of the constituent particles were derived from erosion, weathering, or mass-wasting of pre-existing earth materials, and transported to the place of deposition by mechanical agents such as water, wind, ice and gravity."@en ;
+    rdfs:subClassOf gsrm:Clastic_Sedimentary_Material,
+        gsrm:Sediment .
+
+gsrm:Clastic_Sedimentary_Rock a owl:Class ;
+    rdfs:label "clastic sedimentary rock"@en ;
+    dct:source "SLTTs 2004; Neuendorf et al. 2005"@en ;
+    rdfs:comment "Sedimentary rock in which at least 50 percent of the constituent particles were derived from erosion, weathering, or mass-wasting of pre-existing earth materials, and transported to the place of deposition by mechanical agents such as water, wind, ice and gravity."@en,
+        "The conglomerate, sandstone, mudstone, and wackestone categories are not defined as kinds of clastic sedimentary rocks because rocks meeting their purely grainsize based definitions might also be iron-rich, phosphatic, or carbonate. This is based on GeoSciML allowance to assign rocks to more than one lithology category. For example to categorize a rock as a clastic conglomerate requires assignment ot the 'clastic sedimentary rock' category and to the 'conglomerate' category. Particularly for fine-grained sedimentary rocks, distinction of 'intrabasinal' versus 'clastic' genesis can be very interpretive. In practice the use of clastic mudstone terminology as opposed to carbonate mudstone terminology may be dermined by a priori knowledge about the rock being categorized. If it is associated with other clastic rocks, the clastic categories will be favored, if with cabonate rocks, the carbonate categories will be favored."@en ;
+    rdfs:subClassOf gsrm:Clastic_Sedimentary_Material,
+        gsrm:Sedimentary_Rock ;
+    gsmin:mindatid "min-50895" ;
+    gsmin:mindaturl "https://mindat.org/min-50895.html" .
+
+gsrm:Composite_Genesis_Material a owl:Class ;
+    rdfs:label "composite genesis material"@en ;
+    dct:source "SLTTm 2004"@en ;
+    rdfs:comment "Material of unspecified consolidation state formed by geological modification of pre-existing materials outside the realm of igneous and sedimentary processes. Includes rocks formed by impact metamorphism, standard dynamothermal metamorphism, brittle deformation, weathering, metasomatism and hydrothermal alteration (diagenesis is a sedimentary process in this context)."@en ;
+    rdfs:subClassOf gsog:Rock_Material .
+
+gsrm:Composite_Genesis_Rock a owl:Class ;
+    rdfs:label "composite genesis rock"@en ;
+    dct:source "SLTTm 2004"@en ;
+    rdfs:comment "Rock formed by geological modification of pre-existing rocks outside the realm of igneous and sedimentary processes. Includes rocks formed by impact metamorphism, standard dynamothermal metamorphism, brittle deformation, weathering, metasomatism and hydrothermal alteration (diagenesis is a sedimentary process in this context)."@en ;
+    rdfs:subClassOf gsrm:Composite_Genesis_Material,
+        gsrm:Rock .
+
+gsrm:Consolidation_Degree_Value a owl:Class ;
+    rdfs:label "Consolidation degree category value"@en ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom gsrm:Consolidation_Degree ;
+            owl:onProperty gsoc:isValueOf ],
+        gsoc:Named_Value .
+
+gsrm:Foiditoid a owl:Class ;
+    rdfs:label "foiditoid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Fine grained crystalline rock containing less than 90 percent mafic minerals and more than 60 percent feldspathoid minerals in the QAPF fraction. Includes rocks defined modally in QAPF field 15 or chemically in TAS field F."@en ;
+    rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
+    skos:altLabel "foidite (sensu lato)"@en,
+        "foiditic rock"@en ;
+    gsmin:mindatid "min-50679" ;
+    gsmin:mindaturl "https://mindat.org/min-50679.html" .
+
+gsrm:Granitoid a owl:Class ;
+    rdfs:label "granitoid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Phaneritic crystalline igneous rock consisting of quartz, alkali feldspar and/or plagioclase. Includes rocks defined modally in QAPF fields 2, 3, 4 and 5 as alkali feldspar granite, granite, granodiorite or tonalite."@en ;
+    rdfs:subClassOf gsrm:Acidic_Igneous_Rock,
+        gsrm:Phaneritic_Igneous_Rock ;
+    skos:altLabel "granitic rock"@en ;
+    gsmin:mindatid "min-48126" ;
+    gsmin:mindaturl "https://mindat.org/min-48126.html" .
+
+gsrm:Gravel_Size_Sediment a owl:Class ;
+    rdfs:label "gravel size sediment"@en ;
+    dct:source "SLTTs 2004; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
+    rdfs:comment "Sediment containing greater than 30 percent gravel-size particles (greater than 2.0 mm diameter). Composition or gensis of clasts not specified."@en ;
+    rdfs:subClassOf gsrm:Sediment .
+
+gsrm:Tephritoid a owl:Class ;
+    rdfs:label "tephritoid"@en ;
+    dct:source "LeMaitre et al. 2002"@en ;
+    rdfs:comment "Fine grained igneous rock than contains less than 90 percent mafic minerals, between 10 and 60 percent feldspathoid mineral in the QAPF fraction and has a plagioclase to total feldspar ratio greater than 0.5. Includes rocks classified in QAPF field 13 and 14 or chemically in TAS field U1 as basanite or tephrite."@en ;
+    rdfs:subClassOf gsrm:Fine_Grained_Igneous_Rock ;
+    skos:altLabel "tephritic rock"@en ;
+    gsmin:mindatid "min-50703" ;
+    gsmin:mindaturl "https://mindat.org/min-50703.html" .
+
+gsrm:Ultramafic_Igneous_Rock a owl:Class ;
+    rdfs:label "ultramafic igneous rock"@en ;
+    dct:source "LeMaitre et al. 2002; Gillespie and Styles 1999"@en ;
+    rdfs:comment "Igneous rock that consists of greater than 90 percent mafic minerals."@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock ;
+    gsmin:mindatid "min-48401" ;
+    gsmin:mindaturl "https://mindat.org/min-48401.html" .
+
+gsrm:indurated a owl:Class ;
+    rdfs:label "indurated"@en ;
+    dct:source "NADM sedimentary rock vocabulary NADM sedimentary rock vocabulary (https://pubs.usgs.gov/of/2004/1451/sltt/appendixC/appendixC_pdf.zip)  SLTTs 2004,  after Bowles 1987"@en ;
+    rdfs:comment "Requires blasting or heavy equipment to loosen, Relative density 0.9-1.0. Rings to blow of hammer."@en ;
+    rdfs:subClassOf gsrm:consolidated .
+
+gsrm:Carbonate_Sediment a owl:Class ;
+    rdfs:label "carbonate sediment"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Sediment in which at least 50 percent of the primary and/or recrystallized constituents are composed of one (or more) of the carbonate minerals calcite, aragonite and dolomite, in particles of intrabasinal origin."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Material,
+        gsrm:Sediment ;
+    gsmin:mindatid "min-51423" ;
+    gsmin:mindaturl "https://mindat.org/min-51423.html" .
+
+gsrm:Foliated_Metamorphic_Rock a owl:Class ;
+    rdfs:label "foliated metamorphic rock"@en ;
+    dct:source "based on NADM SLTT metamorphic"@en ;
+    rdfs:comment "Metamorphic rock in which 10 percent or more of the contained mineral grains are elements in a planar or linear fabric. Cataclastic or glassy character precludes classification with this concept."@en ;
+    rdfs:subClassOf gsrm:Metamorphic_Rock .
+
+gsrm:Igneous_Material a owl:Class ;
+    rdfs:label "igneous material"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Earth material formed as a result of igneous processes, eg. intrusion and cooling of magma in the crust, volcanic eruption."@en ;
+    rdfs:subClassOf gsog:Rock_Material .
+
+gsrm:Metasomatic_Rock a owl:Class ;
+    rdfs:label "metasomatic rock"@en ;
+    dct:source "This vocabulary"@en ;
+    rdfs:comment "Rock that has fabric and composition indicating open-system mineralogical and chemical changes in response to interaction with a fluid phase, typically water rich."@en,
+        "SLTTm (2004) proposed the following criteria to distinguish hydrothermally altered or metasomatic rock from igneous rock. \"The rock is classified as metamorphic if (1) the texture has been modified such that it can no longer be considered igneous, (2) the bulk composition of the rock is inconsistent with compositions that can be derived purely from a magma and associated processes such as assimilation and differentiation, or (3) minerals inconsistent with magmatic crystallization are present.\""@en ;
+    rdfs:subClassOf gsrm:Composite_Genesis_Rock .
+
+gsrm:Mud_Size_Sediment a owl:Class ;
+    rdfs:label "mud size sediment"@en ;
+    dct:source "based on SLTTs 2004; Neuendorf et al. 2005; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
+    rdfs:comment "Sediment consisting of less than 30 percent gravel-size (2 mm) particles and with a mud-size to sand-size particle ratio greater than 1. Clasts may be of any composition or origin.  BGS  (Hallsworth and Knox, 1999, p. 9) define the  'upper size limit of mud ... at 32 micrometers (.032 mm)', but Wentworth scale and Krumbein scale put boundary at .064 or .062 mm (inidistinguishable difference in rocks...) BGS 'mud-grade sediment' or sedimentary rock definition is 'over 75% of the clasts smaller than  .032 mm', which is narrower than the definition here."@en ;
+    rdfs:subClassOf gsrm:Sediment .
+
+gsrm:Generic_Mudstone a owl:Class ;
+    rdfs:label "generic mudstone"@en ;
+    dct:source "Pettijohn et al. 1987 referenced in Hallsworth and Knox 1999; extrapolated from Folk, 1954, Figure 1a; particle sizes defined from Krumbein phi scale (W C Krumbein and L L Sloss, Stratigraphy and Sedimentation, 2nd edition, Freeman, San Francisco, 1963; Krumbein and Pettijohn, 1938, Manual of Sedimentary Petrography: New York, Appleton Century Co., Inc.)"@en ;
+    rdfs:comment "Distinction of intrabasinal, diagenetic, or clastic genesis for very fine-grained carbonate minerals is so interpretive that it is proposed to not define the mudstone category based on intrabasinal vs epiclastic distinction required for clastic sedimentary rock-carbonate sedimentary rock categorization in this system. Schnurrenberger, D., Russell, J. and Kelts, K., 2003, Classification of lacustrine sediments based on sedimentary components: Journal of Paleolimnology, v.29, p141-154."@en,
+        "Sedimentary rock consisting of less than 30 percent gravel-size (2 mm) particles and with a mud to sand ratio greater than 1. Clasts may be of any composition or origin."@en ;
+    rdfs:subClassOf gsrm:Sedimentary_Rock .
+
+gsrm:Rock a owl:Class ;
+    rdfs:label "rock"@en ;
+    dct:source "Jackson, 1997; NADM C1 2004; Neuendorf et al 2005"@en ;
+    rdfs:comment "Consolidated aggregate of one or more EarthMaterials, or a body of undifferentiated mineral matter, or of solid organic material. Includes mineral aggregates such as granite, shale, marble; glassy matter such as obsidian; and organic material such a coal. Excludes unconsolidated materials."@en ;
+    rdfs:subClassOf gsog:Rock_Material .
+
+gsrm:Sedimentary_Material a owl:Class ;
+    rdfs:label "sedimentary material"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Material formed by accumulation of solid fragmental material deposited by air, water or ice, or material that accumulated by other natural agents such as chemical precipitation from solution or secretion by organisms. Includes both sediment and sedimentary rock. Includes epiclastic deposits. All stated composition criteria are based on the mineral/ compound material (GeoSciML term)/particulate fraction of the material, irrespective of porosity or the pore-fluid. No distinctions are made based on porosity or pore fluid composition (except organic rich sediment in which liquid hydrocarbon content may be considered)."@en ;
+    rdfs:subClassOf gsog:Rock_Material .
+
+gsrm:Fine_Grained_Igneous_Rock a owl:Class ;
+    rdfs:label "fine grained igneous rock"@en ;
+    dct:source "Gillespie and Styles 1999; LeMaitre et al. 2002"@en ;
+    rdfs:comment "Igneous rock in which the framework of the rock consists of crystals that are too small to determine mineralogy with the unaided eye; framework may include up to 50 percent glass. A significant percentage of the rock by volume may be phenocrysts. Includes rocks that are generally called volcanic rocks."@en,
+        "Need to make decision as to whether devitrified glass should be considered glass or microcrystalline framework for purposes of categorization"@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock ;
+    skos:altLabel "volcanic rock"@en .
+
+gsrm:Sediment a owl:Class ;
+    rdfs:label "sediment"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Unconsolidated material consisting of an aggregation of particles transported or deposited by air, water or ice, or that accumulated by other natural agents, such as chemical precipitation, and that forms in layers on the Earth's surface. Includes epiclastic deposits."@en ;
+    rdfs:subClassOf gsrm:Natural_Unconsolidated_Material,
+        gsrm:Sedimentary_Material ;
+    gsmin:mindatid "min-51422" ;
+    gsmin:mindaturl "https://mindat.org/min-51422.html" .
+
+gsrm:Sedimentary_Rock a owl:Class ;
+    rdfs:label "sedimentary rock"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Rock formed by accumulation and cementation of solid fragmental material deposited by air, water or ice, or as a result of other natural agents, such as precipitation from solution, the accumulation of organic material, or from biogenic processes, including secretion by organisms. Includes epiclastic deposits."@en ;
+    rdfs:subClassOf gsrm:Rock,
+        gsrm:Sedimentary_Material ;
+    gsmin:mindatid "min-51426" ;
+    gsmin:mindaturl "https://mindat.org/min-51426.html" .
+
+gsrm:Carbonate_Sedimentary_Rock a owl:Class ;
+    rdfs:label "carbonate sedimentary rock"@en ;
+    dct:source "SLTTs 2004"@en ;
+    rdfs:comment "Particularly for fine-grained sedimentary rocks, distinction of 'intrabasinal' versus 'clastic' genesis can be very interpretive. In practice the use of clastic mudstone terminology as opposed to carbonate mudstone terminology may be dermined by a priori knowledge about the rock being categorized. If it is associated with other clastic rocks, the clastic categories will be favored, if with cabonate rocks, the carbonate categories will be favored. Carbonate rock subcatgories are defined on two orthogonal dimensions--mineralogy (calcitic vs. dolomitic vs non-carbonate impurities), and texture. The texture categories used here are those of Dunham (1962), and involve grain size (matrix vs. grains/allochems), fabric (matrix vs. grain supported), and genesis (bound, frame, or fragmental). The textural approach used for carbonate rocks is conceptually incompatible with that used for clastic sedimentary rocks, which is solely grain size or mineralogy based. This leads to problems in the vocabulary for rocks of mixed siliclastic/carbonate mineralogy (grainstone vs. sandstone, carbonate mudstone vs. carbonate rich mudstone, how to accomodate marlstone...)."@en,
+        "Sedimentary rock in which at least 50 percent of the primary and/or recrystallized constituents are composed of one (or more) of the carbonate minerals calcite, aragonite, magnesite or dolomite."@en ;
+    rdfs:subClassOf gsrm:Carbonate_Sedimentary_Material,
+        gsrm:Sedimentary_Rock .
+
+gsrm:Igneous_Rock a owl:Class ;
+    rdfs:label "igneous rock"@en ;
+    dct:source "Neuendorf et al 2005"@en ;
+    rdfs:comment "rock formed as a result of igneous processes, for example intrusion and cooling of magma in the crust, or volcanic eruption."@en ;
+    rdfs:subClassOf gsrm:Igneous_Material,
+        gsrm:Rock ;
+    gsmin:mindatid "min-48017" ;
+    gsmin:mindaturl "https://mindat.org/min-48017.html" .
+
+gsrm:Metamorphic_Rock a owl:Class ;
+    rdfs:label "metamorphic rock"@en ;
+    dct:source "Jackson 1997"@en ;
+    rdfs:comment "Robertson (1999, Classification of metamorphic rocks: British Geological Survey Research Report, RR 99–02) defines the boundary between diagenesis and metamorphism in sedimentary rocks as follows: “…the boundary between diagenesis and metamorphism is somewhat arbitrary and strongly dependent on the lithologies involved. For example changes take place in organic materials at lower temperatures than in rocks dominated by silicate minerals. In mudrocks, a white mica (illite) crystallinity value of less than 0.42 Delta 2 Theta obtained by X-ray diffraction analysis, is used to define the onset of metamorphism (Kisch, 1991). In this scheme, the first appearance of glaucophane, lawsonite, paragonite, prehnite, pumpellyite or stilpnomelane is taken to indicate the lower limit of metamorphism (Frey and Kisch, 1987; Bucher and Frey, 1994; Frey and Robinson, 1998). Most workers agree that such mineral growth starts at 150 +/- 50° C in silicate rocks. Many lithologies may show no change in mineralogy under these conditions and hence the recognition of the onset of metamorphism will vary with bulk composition.”"@en,
+        "Rock formed by solid-state mineralogical, chemical and/or structural changes to a pre-existing rock, in response to marked changes in temperature, pressure, shearing stress and chemical environment."@en ;
+    rdfs:subClassOf gsrm:Composite_Genesis_Rock ;
+    gsmin:mindatid "min-51421" ;
+    gsmin:mindaturl "https://mindat.org/min-51421.html" .
+
+gsrm:Phaneritic_Igneous_Rock a owl:Class ;
+    rdfs:label "phaneritic igneous rock"@en ;
+    dct:source "Neuendorf et al. 2005"@en ;
+    rdfs:comment "Igneous rock in which the framework of the rock consists of individual crystals that can be discerned with the unaided eye. Bounding grain size is on the order of 32 to 100 microns. Igneous rocks with 'exotic' composition are excluded from this concept."@en ;
+    rdfs:subClassOf gsrm:Igneous_Rock ;
+    skos:altLabel "coarse grained crystalline igneous rock"@en,
+        "plutonic rock"@en .
+
+gsrm:altered_rock a owl:Class ;
+    rdfs:label "Altered, type not specified "@en ;
+    rdfs:comment "Rock material has been changed by some subsurface alteration process, but the nature of the alteration is not specified."@en ;
+    rdfs:subClassOf gsrm:Metasomatic_Rock .
+


### PR DESCRIPTION
One of my projects in USGS is building a knowledgebase focused toward our broad geoscience portfolio. We're building this in a Wikibase because of the many tools that our folks can use to contribute through time, but also because of the adjacency with Wikidata and a desire to see more of our knowledge represented in the "Global Knowledge Commons." 

We initially took a crack at incorporating basic pointers to many Mindat entities that we also need, but as we've moved things along, some of our geologists have expressed some frustration with liberties taken and insufficient traceability to original scientific reference sources. The Geoscience Ontology seems like it is going to be a much better amalgamation for us to work from, and so I'm going through your modeling to see how best to do that. I do want to retain our linkages to Mindat as you have done for minerals in the GSMIN module.

This pull request is for some addition to the GSMR module with gsmin:mindatid and gsmin:mindaturl values that come from work we already did on pulling the Mindat rock classification. I'll be unwinding that in our graph in favor of the GSMR classes, but I thought I'd push the identifier linkages back in case you want to incorporate them here. The python code where I did this is in a branch [here](https://github.com/skybristol/geokb/blob/skybristol/issue25/utilities/Mindat%20rock%20classes%20in%20GSO%20rock%20materials.ipynb).

I'll have other work going on once we work through a few more aspects of the GSO to translate what we want to work with into the Wikibase framework, which is fundamentally a triple store but with some nuance.